### PR TITLE
Fix timeout handling

### DIFF
--- a/ob1k-cache/pom.xml
+++ b/ob1k-cache/pom.xml
@@ -41,6 +41,10 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Fix timeout handling, and make sure the loader gets called upon cache timeouts unless there's a global timeout.

Also added a global TO counter.

I didn't touch the getBulkAsync() method - it requires some extra thinking... later...