### PR TITLE
[ob1k-cache] Added metrics to MemcacheClient

### DIFF
--- a/ob1k-cache/pom.xml
+++ b/ob1k-cache/pom.xml
@@ -41,10 +41,14 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
     </dependency>
 
   </dependencies>

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricHolder.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricHolder.java
@@ -1,0 +1,43 @@
+package com.outbrain.ob1k.cache.memcache;
+
+import com.outbrain.swinfra.metrics.api.Counter;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+import com.outbrain.swinfra.metrics.api.Timer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+
+/**
+ * Holds all metrics used for monitoring MemcacheClient.
+ *
+ * @author hunchback
+ */
+public class MetricHolder {
+  protected MetricOpCache cache;
+  protected MetricOpLoader load;
+  protected Counter delete;
+
+  public MetricOpCache getCache() {
+    return cache;
+  }
+
+  public MetricOpLoader getLoad() {
+    return load;
+  }
+
+  public Counter getDelete() {
+    return delete;
+  }
+
+  public MetricHolder(final String component, MetricFactory metricFactory) {
+      if (metricFactory == null) {
+        metricFactory = mock(MetricFactory.class);
+        when(metricFactory.createCounter(any(String.class),any(String.class))).thenReturn(mock(Counter.class));
+        when(metricFactory.createTimer(any(String.class),any(String.class))).thenReturn(mock(Timer.class));
+      }
+      cache = new MetricOpCache(metricFactory, component, "cache");
+      load = new MetricOpLoader(metricFactory, component, "load");
+      delete = metricFactory.createCounter(component, "cancelOperationCount");
+  }
+}

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricOpBase.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricOpBase.java
@@ -1,0 +1,51 @@
+package com.outbrain.ob1k.cache.memcache;
+
+import java.util.concurrent.TimeoutException;
+
+import com.outbrain.ob1k.concurrent.Try;
+import com.outbrain.swinfra.metrics.api.Counter;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+import com.outbrain.swinfra.metrics.api.Timer;
+
+/**
+ * Holds a set of metrics used for measuring cache operations.
+ *
+ * @author hunchback
+ */
+public abstract class MetricOpBase {
+  protected final Counter errors;
+  protected final Counter timeouts;
+  protected final Timer elapsed;
+
+  public MetricOpBase(final MetricFactory metricFactory, final String component,
+                      final String prefix) {
+    errors = metricFactory.createCounter(component, prefix + "ErrorsCount");
+    timeouts = metricFactory.createCounter(component, prefix + "TimeoutsCount");
+    elapsed = metricFactory.createTimer(component, prefix + "ElapsedTime");
+  }
+
+  public Timer.Context start() {
+    return elapsed.time();
+  }
+
+  public void finished(final Try<?> res, final Timer.Context timer,
+                       Counter hit, Counter miss, Counter err, Counter timeout) {
+    timer.stop();
+    if (res.isSuccess()) {
+      if (res.getValue() == null) {
+        err.inc();
+      } else {
+        hit.inc();
+      }
+    } else {
+      final Throwable error = res.getError();
+      err.inc();
+      if (error instanceof TimeoutException) {
+        timeout.inc();
+      }
+    }
+  }
+
+  public abstract void finished(Try<?> res, final Timer.Context timer);
+}
+

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricOpCache.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricOpCache.java
@@ -1,0 +1,29 @@
+package com.outbrain.ob1k.cache.memcache;
+
+import com.outbrain.ob1k.concurrent.Try;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+import com.outbrain.swinfra.metrics.api.Counter;
+import com.outbrain.swinfra.metrics.api.Timer;
+
+/**
+ * Holds a set of metrics used for measuring cache operations.
+ *
+ * @author hunchback
+ */
+public class MetricOpCache extends MetricOpBase {
+  private final Counter hit;
+  private final Counter miss;
+
+  public MetricOpCache(final MetricFactory metricFactory, final String component,
+                       final String prefix) {
+    super(metricFactory, component, prefix);
+    hit = metricFactory.createCounter(component, prefix + "HitCount");
+    miss = metricFactory.createCounter(component, prefix + "MissCount");
+  }
+
+  @Override
+  public void finished(Try<?> res, final Timer.Context timer) {
+    finished(res, timer, hit, miss, errors, timeouts);
+  }
+}
+

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricOpLoader.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MetricOpLoader.java
@@ -1,0 +1,27 @@
+package com.outbrain.ob1k.cache.memcache;
+
+import com.outbrain.ob1k.concurrent.Try;
+import com.outbrain.swinfra.metrics.api.Counter;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+import com.outbrain.swinfra.metrics.api.Timer;
+
+/**
+ * Holds a set of metrics used for measuring load operations.
+ *
+ * @author hunchback
+ */
+public class MetricOpLoader extends MetricOpBase {
+  private final Counter success;
+
+  public MetricOpLoader(final MetricFactory metricFactory, final String component,
+                        final String prefix) {
+    super(metricFactory, component, prefix);
+    success = metricFactory.createCounter(component, prefix + "SuccessCount");
+  }
+
+  @Override
+  public void finished(final Try<?> res, final Timer.Context timer) {
+    finished(res, timer, success, success, errors, timeouts);
+  }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,6 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <scope>test</scope>
         <version>1.9.5</version>
       </dependency>
 


### PR DESCRIPTION
replaced (metricFactory != null) with fine-grained checkin of individual metrics