### PR TITLE
Changed 'JavaConversions.asJavaList' to 'JavaConversions.seqAsJavaList'

### DIFF
--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/BasicDao.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/BasicDao.java
@@ -111,7 +111,7 @@ public class BasicDao {
       final List<T> response = new ArrayList<>();
       if (rowsOption.isDefined()) {
         final ResultSet resultSet = rowsOption.get();
-        final List<String> columnNames = JavaConversions.asJavaList(resultSet.columnNames());
+        final List<String> columnNames = JavaConversions.seqAsJavaList(resultSet.columnNames());
 
         final Iterator<RowData> rows = resultSet.iterator();
         while (rows.hasNext()) {
@@ -168,7 +168,7 @@ public class BasicDao {
 
       if (rowsOption.isDefined()) {
         final ResultSet resultSet = rowsOption.get();
-        final List<String> columnNames = JavaConversions.asJavaList(resultSet.columnNames());
+        final List<String> columnNames = JavaConversions.seqAsJavaList(resultSet.columnNames());
 
         final Iterator<RowData> rows = resultSet.iterator();
         if (rows.hasNext()) {


### PR DESCRIPTION
Changed 'JavaConversions.asJavaList' (which was depricated in Scala 2.9) to 'JavaConversions.seqAsJavaList' to support migration to Scala 2.11.