### PR TITLE
Cross DC query in Consul

### DIFF
--- a/ob1k-consul/src/main/java/com/outbrain/ob1k/consul/ConsulAPI.java
+++ b/ob1k-consul/src/main/java/com/outbrain/ob1k/consul/ConsulAPI.java
@@ -68,6 +68,7 @@ public class ConsulAPI {
             return new ClientBuilder<>(ConsulHealth.class)
                     .setTargetProvider(new SimpleTargetProvider(AGENT_BASE_URL + "health"))
                     .bindEndpoint("filterDcLocalHealthyInstances", HttpRequestMethodType.GET, "service/{service}?passing=true&tag={filterTag}&stale=true")
+                    .bindEndpoint("filterDcHealthyInstances", HttpRequestMethodType.GET, "service/{service}?passing=true&dc={dc}&tag={filterTag}&stale=true")
                     .bindEndpoint("pollHealthyInstances", HttpRequestMethodType.GET, "service/{service}?passing=true&stale=true&tag={filterTag}&index={index}&wait=" + timeoutSeconds + "s")
                     .bindEndpoint("fetchInstancesHealth", HttpRequestMethodType.GET, "service/{service}?dc={dc}&stale=true")
                     .bindEndpoint("fetchInstancesChecks", HttpRequestMethodType.GET, "checks/{service}?dc={dc}&stale=true")

--- a/ob1k-consul/src/main/java/com/outbrain/ob1k/consul/ConsulHealth.java
+++ b/ob1k-consul/src/main/java/com/outbrain/ob1k/consul/ConsulHealth.java
@@ -15,7 +15,7 @@ public interface ConsulHealth extends Service {
 
   ComposableFuture<List<HealthInfoInstance>> filterDcLocalHealthyInstances(final String service, final String filterTag);
 
-  ComposableFuture<List<HealthInfoInstance>> filterDcHealthyInstances(final String dc, final String service, final String filterTag);
+  ComposableFuture<List<HealthInfoInstance>> filterDcHealthyInstances(final String service, final String dc, final String filterTag);
 
   ComposableFuture<TypedResponse<List<HealthInfoInstance>>> pollHealthyInstances(final String service, final String filterTag, final long index);
 

--- a/ob1k-consul/src/main/java/com/outbrain/ob1k/consul/ConsulHealth.java
+++ b/ob1k-consul/src/main/java/com/outbrain/ob1k/consul/ConsulHealth.java
@@ -15,6 +15,8 @@ public interface ConsulHealth extends Service {
 
   ComposableFuture<List<HealthInfoInstance>> filterDcLocalHealthyInstances(final String service, final String filterTag);
 
+  ComposableFuture<List<HealthInfoInstance>> filterDcHealthyInstances(final String dc, final String service, final String filterTag);
+
   ComposableFuture<TypedResponse<List<HealthInfoInstance>>> pollHealthyInstances(final String service, final String filterTag, final long index);
 
   ComposableFuture<List<HealthInfoInstance>> fetchInstancesHealth(final String service, final String dc);


### PR DESCRIPTION
Added an endpoint that filters healthy instances for a specific DC (As opposed to local dc only)