### PR TITLE
Making batchUnordered much less stack hungry.

### DIFF
--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
@@ -1,5 +1,6 @@
 package com.outbrain.ob1k.concurrent;
 
+import com.google.common.collect.ImmutableSet;
 import com.outbrain.ob1k.concurrent.combiners.BiFunction;
 import com.outbrain.ob1k.concurrent.combiners.TriFunction;
 import com.outbrain.ob1k.concurrent.eager.EagerComposableFuture;
@@ -156,7 +157,7 @@ public class ComposableFutureTest {
     final List<Integer> nums = IntStream.range(1, 100_000).boxed().collect(toList());
     final ComposableFuture<List<Integer>> res = batchUnordered(nums, 8, num -> ComposableFutures.schedule(() -> num, 10, TimeUnit.MICROSECONDS));
     final List<Integer> results = res.get();
-    nums.removeAll(results);
+    nums.removeAll(ImmutableSet.copyOf(results));
     assertTrue(nums.isEmpty());
   }
 


### PR DESCRIPTION
This version of batchUnordered treats the list of elements as a balanced binary tree, by leveraging the heap-on-array structure, aiming to make the recursion depth O(log(n)) instead of O(n).
It uses a NavigableMap to maintain the set of pending nodes, and to get the index of the pending node which is highest in the tree.
The algorithm does a Pre-order traversal of the tree. When it encounters a node processed by another thread, it hops to the highest node in the tree which is not yet processed. This increases the chance that the recursion will be shallow, and reduces the number of times an already processed node is encountered.