### PR TITLE
Batch unordered

### DIFF
--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFutures.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFutures.java
@@ -3,8 +3,6 @@ package com.outbrain.ob1k.concurrent;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.outbrain.ob1k.concurrent.combiners.BiFunction;
 import com.outbrain.ob1k.concurrent.combiners.Combiner;
 import com.outbrain.ob1k.concurrent.combiners.FutureBiFunction;
@@ -39,8 +37,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static java.util.Collections.singletonList;
 
 /**
  * A set of helpers for ComposableFuture
@@ -259,11 +255,18 @@ public class ComposableFutures {
         return left.flatMap(leftResults -> {
           final int rightIndex = leftIndex + 1;
           final ComposableFuture<List<R>> right = processTree(elements, rightIndex, indexes, producer);
-          return right.flatMap(rightResults ->
-                  ComposableFutures.fromValue(Lists.newArrayList(Iterables.concat(singletonList(rootResult), leftResults, rightResults))));
+          return right.map(rightResults -> concat(rootResult, leftResults, rightResults));
         });
       });
     }
+  }
+
+  private static <R> List<R> concat(R rootResult, List<R> leftResults, List<R> rightResults) {
+    List<R> results = new ArrayList<>(1 + leftResults.size() + rightResults.size());
+    results.add(rootResult);
+    results.addAll(leftResults);
+    results.addAll(rightResults);
+    return results;
   }
 
   /**

--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFutures.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFutures.java
@@ -279,6 +279,8 @@ public class ComposableFutures {
       int node = pendingNodeLowerBound.get();
       for (; node <= elements.size() && pendingNodes.get(node - 1) == 1; node++);
 
+      // Rarely, we may loose a race and set pendingNodeLowerBound to a lower value than
+      // the latest value, but it will only affect performance.
       pendingNodeLowerBound.set(node + 1);
       return processTree(elements, node, pendingNodes, pendingNodeLowerBound, producer);
     }

--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
@@ -1,5 +1,6 @@
 package com.outbrain.ob1k.concurrent;
 
+import com.google.common.collect.ImmutableSet;
 import com.outbrain.ob1k.concurrent.combiners.BiFunction;
 import com.outbrain.ob1k.concurrent.combiners.TriFunction;
 import com.outbrain.ob1k.concurrent.eager.EagerComposableFuture;
@@ -156,7 +157,7 @@ public class ComposableFutureTest {
     final List<Integer> nums = IntStream.range(1, 100_000).boxed().collect(toList());
     final ComposableFuture<List<Integer>> res = batchUnordered(nums, 8, num -> ComposableFutures.schedule(() -> num, 10, TimeUnit.MICROSECONDS));
     final List<Integer> results = res.get();
-    nums.removeAll(results);
+    nums.removeAll(ImmutableSet.copyOf(results));
     assertTrue(nums.isEmpty());
   }
 

--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
@@ -40,7 +40,8 @@ import static com.outbrain.ob1k.concurrent.ComposableFutures.toObservable;
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertTrue;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
 
 /**
  * User: aronen
@@ -155,10 +156,10 @@ public class ComposableFutureTest {
   @Test
   public void testBatchUnordered() throws Exception {
     final List<Integer> nums = IntStream.range(1, 100_000).boxed().collect(toList());
-    final ComposableFuture<List<Integer>> res = batchUnordered(nums, 8, num -> ComposableFutures.schedule(() -> num, 10, TimeUnit.MICROSECONDS));
-    final List<Integer> results = res.get();
-    nums.removeAll(ImmutableSet.copyOf(results));
-    assertTrue(nums.isEmpty());
+    final ComposableFuture<List<String>> res = batchUnordered(nums, 8, num -> ComposableFutures.schedule(() -> String.valueOf(num), 10, TimeUnit.NANOSECONDS));
+    final List<String> results = res.get();
+    assertEquals(nums.size(), results.size());
+    assertEquals(nums.stream().map(Object::toString).collect(toSet()), ImmutableSet.copyOf(results));
   }
 
   @Test


### PR DESCRIPTION
This version of batchUnordered treats the list of elements as a balanced binary tree, by leveraging the heap-on-array structure, aiming to make the recursion depth O(log(n)) instead of O(n).
It uses an AtomicIntegerArray to maintain the set of pending nodes, and uses an auxiliary AtomicLong to get the index of the pending node which is left-most and highest in the tree.
The algorithm does a Pre-order traversal of the tree. When it encounters a node processed by another thread, it hops to the left-most, highest node in the tree which is not yet processed. This increases the chance that the recursion will be shallow, and reduces the number of times an already processed node is encountered.