### PR TITLE
Upgrade netty 4.1.8.final

### DIFF
--- a/ob1k-core/pom.xml
+++ b/ob1k-core/pom.xml
@@ -29,7 +29,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.outbrain.swinfra</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>ob1k-http</artifactId>
     </dependency>
 

--- a/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/HttpRequestDispatcherHandler.java
+++ b/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/HttpRequestDispatcherHandler.java
@@ -1,12 +1,13 @@
 package com.outbrain.ob1k.server.netty;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaders.Values.KEEP_ALIVE;
-import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
-import static io.netty.handler.codec.http.HttpHeaders.isKeepAlive;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpUtil.is100ContinueExpected;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 import java.io.IOException;
@@ -101,7 +102,7 @@ public class HttpRequestDispatcherHandler extends SimpleChannelInboundHandler<Ob
     if (msg instanceof HttpRequest) {
       request = (HttpRequest) msg;
 
-      final String uri = request.getUri();
+      final String uri = request.uri();
       final QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri);
       final String path = queryStringDecoder.path();
       if (!path.startsWith(contextPath)) {
@@ -260,7 +261,7 @@ public class HttpRequestDispatcherHandler extends SimpleChannelInboundHandler<Ob
       internalErrors.inc();
     }
 
-    logger.warn("Internal error while processing URI: " + request.getUri() + " from remote address " + ctx.channel().remoteAddress(), error);
+    logger.warn("Internal error while processing URI: " + request.uri() + " from remote address " + ctx.channel().remoteAddress(), error);
     try {
       handleResponse(error.toString(), INTERNAL_SERVER_ERROR, request, ctx);
     } catch (final IOException e) {
@@ -289,7 +290,7 @@ public class HttpRequestDispatcherHandler extends SimpleChannelInboundHandler<Ob
   }
 
   private void handleResponse(final FullHttpResponse response, final HttpRequest request, final ChannelHandlerContext ctx) {
-    final boolean keepAlive = isKeepAlive(request);
+    final boolean keepAlive = HttpUtil.isKeepAlive(request);
     if (acceptKeepAlive && keepAlive) {
       response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
       // Add keep alive header as per:
@@ -318,10 +319,10 @@ public class HttpRequestDispatcherHandler extends SimpleChannelInboundHandler<Ob
 
     if (error instanceof IllegalArgumentException) {
       // stack-trace not interesting, as the exception probably because of invocation failure
-      logger.info("The requested URI isn't supported: {}", request.getUri());
+      logger.info("The requested URI isn't supported: {}", request.uri());
       logger.debug("Invocation error: ", error);
     } else {
-      logger.info("The requested URI isn't supported: {}", request.getUri(), error);
+      logger.info("The requested URI isn't supported: {}", request.uri(), error);
     }
     handleResponse(error.toString(), HttpResponseStatus.NOT_IMPLEMENTED, request, ctx);
   }

--- a/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/NettyRequest.java
+++ b/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/NettyRequest.java
@@ -6,12 +6,12 @@ import com.outbrain.ob1k.Request;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.Channel;
-import io.netty.handler.codec.http.Cookie;
-import io.netty.handler.codec.http.CookieDecoder;
+import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.util.CharsetUtil;
 
 import java.io.InputStream;
@@ -45,19 +45,19 @@ public class NettyRequest implements Request {
     this.inner = inner;
     this.content = content;
     this.channel = channel;
-    this.getQueryDecoder = new QueryStringDecoder(inner.getUri());
+    this.getQueryDecoder = new QueryStringDecoder(inner.uri());
     this.contextPath = contextPath;
     this.pathParams = new HashMap<>();
   }
 
   @Override
   public HttpRequestMethodType getMethod() {
-    return HttpRequestMethodType.valueOf(inner.getMethod().name().toUpperCase());
+    return HttpRequestMethodType.valueOf(inner.method().name().toUpperCase());
   }
 
   @Override
   public String getUri() {
-    return inner.getUri();
+    return inner.uri();
   }
 
   @Override
@@ -202,7 +202,7 @@ public class NettyRequest implements Request {
     }
 
     final Cookie cookie = cookies.get(cookieName);
-    return cookie != null ? cookie.getValue() : null;
+    return cookie != null ? cookie.value() : null;
   }
 
   private void populateCookies() {
@@ -211,14 +211,14 @@ public class NettyRequest implements Request {
     final String cookieHeaderValue = inner.headers().get(COOKIE_HEADER);
     if (cookieHeaderValue == null) return;
 
-    final Set<Cookie> cookiesSet = CookieDecoder.decode(cookieHeaderValue);
+    final Set<Cookie> cookiesSet = ServerCookieDecoder.LAX.decode(cookieHeaderValue);
     for (final Cookie cookie : cookiesSet) {
-      cookies.put(cookie.getName(), cookie);
+      cookies.put(cookie.name(), cookie);
     }
   }
 
   @Override
   public String getProtocol() {
-    return inner.getProtocolVersion().text();
+    return inner.protocolVersion().text();
   }
 }

--- a/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/ResourceRegion.java
+++ b/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/ResourceRegion.java
@@ -58,6 +58,11 @@ public class ResourceRegion extends AbstractReferenceCounted implements FileRegi
   }
 
   @Override
+  public long transferred() {
+    return transfered;
+  }
+
+  @Override
   public long transferTo(final WritableByteChannel target, final long position) throws IOException {
     final ByteBuffer buffer;
     if (tempBuffer != null) {
@@ -82,4 +87,23 @@ public class ResourceRegion extends AbstractReferenceCounted implements FileRegi
     return bytesWritten;
   }
 
+  @Override
+  public FileRegion retain() {
+    return (FileRegion) super.retain();
+  }
+
+  @Override
+  public FileRegion touch(final Object hint) {
+    return null;
+  }
+
+  @Override
+  public FileRegion retain(final int increment) {
+    return (FileRegion) super.retain(increment);
+  }
+
+  @Override
+  public FileRegion touch() {
+    return (FileRegion) super.touch();
+  }
 }

--- a/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/ResourceRegion.java
+++ b/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/ResourceRegion.java
@@ -94,7 +94,7 @@ public class ResourceRegion extends AbstractReferenceCounted implements FileRegi
 
   @Override
   public FileRegion touch(final Object hint) {
-    return null;
+    return this;
   }
 
   @Override

--- a/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/ResponseBuilder.java
+++ b/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/ResponseBuilder.java
@@ -5,9 +5,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultCookie;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.ServerCookieEncoder;
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty.util.CharsetUtil;
 
 import java.nio.charset.Charset;
@@ -104,7 +105,7 @@ public class ResponseBuilder {
   }
 
   public ResponseBuilder setContentType(final String contentType) {
-    addHeader(HttpHeaders.Names.CONTENT_TYPE, contentType);
+    addHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
     return this;
   }
 
@@ -113,7 +114,7 @@ public class ResponseBuilder {
   }
 
   public ResponseBuilder addCookie(final String rawCookie) {
-    return addHeader(HttpHeaders.Names.SET_COOKIE, rawCookie);
+    return addHeader(HttpHeaderNames.SET_COOKIE, rawCookie);
   }
 
   public CookieBaker bakeCookie(final String name, final String value) {
@@ -139,7 +140,7 @@ public class ResponseBuilder {
     }
 
     public ResponseBuilder bake() {
-      addCookie(ServerCookieEncoder.encode(cookie));
+      addCookie(ServerCookieEncoder.STRICT.encode(cookie));
       return ResponseBuilder.this;
     }
 

--- a/ob1k-core/src/test/java/com/outbrain/ob1k/server/netty/NettyRequestTest.java
+++ b/ob1k-core/src/test/java/com/outbrain/ob1k/server/netty/NettyRequestTest.java
@@ -31,7 +31,7 @@ public class NettyRequestTest {
     httpHeaders = new DefaultHttpHeaders();
 
     final HttpRequest innerRequest = mock(HttpRequest.class);
-    when(innerRequest.getUri()).thenReturn("http://localhost:8080");
+    when(innerRequest.uri()).thenReturn("http://localhost:8080");
     when(innerRequest.headers()).thenReturn(httpHeaders);
 
     final HttpContent httpContent = mock(HttpContent.class);

--- a/ob1k-http/src/test/java/com/outbrain/ob1k/http/ClientBasicFlowsTest.java
+++ b/ob1k-http/src/test/java/com/outbrain/ob1k/http/ClientBasicFlowsTest.java
@@ -7,6 +7,7 @@ import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -210,7 +211,7 @@ public class ClientBasicFlowsTest {
   public void testBasicAuth() throws Exception {
 
     dispatcher.enqueue(input -> {
-      final String authHeader = input.getHeader(HttpHeaders.Names.AUTHORIZATION).replace("Basic ", "");
+      final String authHeader = input.getHeader(HttpHeaderNames.AUTHORIZATION.toString()).replace("Basic ", "");
       final String credentials = new String(Base64.decode(authHeader));
       return new MockResponse().setBody(credentials);
     });

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.0.31.Final</version>
+        <version>4.1.8.Final</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Upgraded to Netty 4.1.8.Final

1. Removed most usages of deprecated API
2. Please go over the usages of *ServerCookieDecoder* - Not sure we want to STRICT decoder or the LAX one. I think that for backwards compatibility we should choose the LAX, but I went with STRICT since it's the correct option
3. There are still usages of deprecated API in the *NettyRequest* class, not sure what to do with those