### PR TITLE
support for typed exceptions when recovering from error

### DIFF
--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFuture.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFuture.java
@@ -51,244 +51,252 @@ import static com.outbrain.ob1k.concurrent.ComposableFutures.schedule;
  */
 public interface ComposableFuture<T> {
 
-  /**
-   * Continues a future with a handler that will be called only if the original future resulted with success
-   * in case of an error the error is continued forward.
-   *
-   * @param mapper the continuation handler that returns immidiate value
-   * @param <R>    the resulting future type.
-   * @return return a new future that will produce the result either from the handler if successful or the original error.
-   */
-  <R> ComposableFuture<R> map(Function<? super T, ? extends R> mapper);
+    /**
+     * Continues a future with a handler that will be called only if the original future resulted with success
+     * in case of an error the error is continued forward.
+     *
+     * @param mapper the continuation handler that returns immidiate value
+     * @param <R>    the resulting future type.
+     * @return return a new future that will produce the result either from the handler if successful or the original error.
+     */
+    <R> ComposableFuture<R> map(Function<? super T, ? extends R> mapper);
 
-  /**
-   * Continues a future with a handler that will be called only if the original future resulted with success
-   * in case of an error the error is continues forward.
-   *
-   * @param mapper the continuation handler that returns a future
-   * @param <R>    the resulting future type.
-   * @return a new future that will produce the result either from the handler if successful or the original error.
-   */
-  <R> ComposableFuture<R> flatMap(Function<? super T, ? extends ComposableFuture<? extends R>> mapper);
+    /**
+     * Continues a future with a handler that will be called only if the original future resulted with success
+     * in case of an error the error is continues forward.
+     *
+     * @param mapper the continuation handler that returns a future
+     * @param <R>    the resulting future type.
+     * @return a new future that will produce the result either from the handler if successful or the original error.
+     */
+    <R> ComposableFuture<R> flatMap(Function<? super T, ? extends ComposableFuture<? extends R>> mapper);
 
-  /**
-   * Recovers future with a handler that will be called only if the original future failed
-   * in case of success the original result is continued forward.
-   *
-   * @param recover the continuation handler that returns a value or throws an exception.
-   * @return a new future that will produce the original successful value the the result of the handler.
-   */
-  ComposableFuture<T> recover(Function<Throwable, ? extends T> recover);
+    /**
+     * Recovers future with a handler that will be called only if the original future failed
+     * in case of success the original result is continued forward.
+     *
+     * @param recover the continuation handler that returns a value or throws an exception.
+     * @return a new future that will produce the original successful value the the result of the handler.
+     */
+    <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, Function<E, ? extends T> recover);
 
-  /**
-   * Recovers future with a handler that will be called only if the original future failed
-   * in case of success the original result is continued forward.
-   *
-   * @param recover the continuation handler that returns a future
-   * @return a new future that will produce the original successful value the the result of the handler.
-   */
-  ComposableFuture<T> recoverWith(Function<Throwable, ? extends ComposableFuture<? extends T>> recover);
-
-  /**
-   * Continues a future with a handler that will be called whether the future has resulted
-   * in a successful value or an error.
-   *
-   * @param handler the continuation handler that returns a value or throws an exception.
-   * @param <R>     the resulting future type.
-   * @return a new future that will produce the result from the handler.
-   */
-  <R> ComposableFuture<R> always(Function<Try<T>, ? extends R> handler);
-
-  /**
-   * Continues a future with a handler that will be called whether the future has resulted
-   * in a successful value or an error.
-   *
-   * @param handler the continuation handler that returns a future
-   * @param <R>     the resulting future type.
-   * @return a new future that will produce the result from the handler.
-   */
-  <R> ComposableFuture<R> alwaysWith(Function<Try<T>, ? extends ComposableFuture<? extends R>> handler);
-
-  /**
-   * Applies the side-effecting function to the result of the current future,
-   * and returns a new future with same value.
-   *
-   * @param consumer the result consumer for the current future result
-   * @return a future with same value
-   */
-  ComposableFuture<T> andThen(Consumer<? super T> consumer);
-
-  /**
-   * Transforms current future into a successful one regardless of its status, with a {@link Try} to represent
-   * computation status (failure/success).
-   * <p>
-   * ComposableFuture[T](success/failure) => ComposableFuture[Try[T]](success)
-   *
-   * @return a new future of {@link Try[T]}, either Success or Failure depends on computation result.
-   */
-  default ComposableFuture<Try<T>> successful() {
-    return always(__ -> __);
-  }
-
-  /**
-   * Creates delayed future of current one, by provided duration.
-   * Applied on successful result.
-   *
-   * @param duration duration to delay
-   * @param unit time unit
-   * @return delayed future
-   */
-  default ComposableFuture<T> delay(final long duration, final TimeUnit unit) {
-    return flatMap(result -> schedule(() -> result, duration, unit));
-  }
-
-  /**
-   * Ensures that the (successful) result of the current future satisfies the given predicate,
-   * or fails with the given value.
-   *
-   * @param predicate the predicate for the result
-   * @return new future with same value if predicate returns true, else new future with a failure
-   */
-  default ComposableFuture<T> ensure(final Predicate<? super T> predicate) {
-    return flatMap(result -> {
-      if (predicate.test(result)) {
-        return fromValue(result);
-      }
-      return fromError(new NoSuchElementException("predicate is not satisfied"));
-    });
-  }
-
-  /**
-   * Consumes the value(or error) of the future into a consumer.
-   * if the future is lazy the value will be reproduced on each consumption.
-   * if the future is eager the consumer will be served from the cached result.
-   *
-   * @param consumer the consumer.
-   */
-  void consume(Consumer<? super T> consumer);
-
-  /**
-   * Blocks until a value is available for consumption and then return it.
-   * in case of an error the exception is wrapped inside an ExecutionException and thrown.
-   * <p>
-   * DO NOT use in non-blocking environment.
-   *
-   * @return the future value if successful
-   * @throws InterruptedException if the thread has been interrupted
-   * @throws ExecutionException   if the future return an error.
-   */
-  default T get() throws InterruptedException, ExecutionException {
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
-    consume(result -> {
-      resultBox.set(result);
-      latch.countDown();
-    });
-
-    latch.await();
-    final Try<T> result = resultBox.get();
-
-    if (result == null) {
-      throw new ExecutionException(new NullPointerException("no result"));
+    default ComposableFuture<T> recover(Function<Throwable, ? extends T> recover) {
+        return recover(Throwable.class, recover);
     }
 
-    if (result.isSuccess()) {
-      return result.getValue();
+    /**
+     * Recovers future with a handler that will be called only if the original future failed
+     * in case of success the original result is continued forward.
+     *
+     * @param recover the continuation handler that returns a future
+     * @return a new future that will produce the original successful value the the result of the handler.
+     */
+    <E extends Throwable> ComposableFuture<T> recoverWith(Class<E> errorType, Function<E, ? extends ComposableFuture<? extends T>> recover);
+
+    default ComposableFuture<T> recoverWith(Function<Throwable, ? extends ComposableFuture<? extends T>> recover) {
+        return recoverWith(Throwable.class, recover);
     }
 
-    throw new ExecutionException(result.getError());
-  }
+    /**
+     * Continues a future with a handler that will be called whether the future has resulted
+     * in a successful value or an error.
+     *
+     * @param handler the continuation handler that returns a value or throws an exception.
+     * @param <R>     the resulting future type.
+     * @return a new future that will produce the result from the handler.
+     */
+    <R> ComposableFuture<R> always(Function<Try<T>, ? extends R> handler);
 
-  /**
-   * Blocks until a value is available for consumption or until a timeout occurs, and then return the result or error.
-   * in case of an error the exception is wrapped inside an ExecutionException and thrown.
-   * <p>
-   * DO NOT use in non-blocking environment.
-   *
-   * @param timeout max wait time for result.
-   * @param unit    a time unit for the timeout duration
-   * @return the result if successful
-   * @throws InterruptedException if the thread has been interrupted
-   * @throws ExecutionException   if the future return an error
-   * @throws TimeoutException     if result(or error) haven't arrived in the specified time-span.
-   */
-  default T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-    final CountDownLatch countDownLatch = new CountDownLatch(1);
-    final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
-    consume(result -> {
-      resultBox.set(result);
-      countDownLatch.countDown();
-    });
+    /**
+     * Continues a future with a handler that will be called whether the future has resulted
+     * in a successful value or an error.
+     *
+     * @param handler the continuation handler that returns a future
+     * @param <R>     the resulting future type.
+     * @return a new future that will produce the result from the handler.
+     */
+    <R> ComposableFuture<R> alwaysWith(Function<Try<T>, ? extends ComposableFuture<? extends R>> handler);
 
-    if (countDownLatch.await(timeout, unit)) {
-      final Try<T> result = resultBox.get();
+    /**
+     * Applies the side-effecting function to the result of the current future,
+     * and returns a new future with same value.
+     *
+     * @param consumer the result consumer for the current future result
+     * @return a future with same value
+     */
+    ComposableFuture<T> andThen(Consumer<? super T> consumer);
 
-      if (result == null) {
-        throw new ExecutionException(new NullPointerException("No result"));
-      }
-
-      if (result.isSuccess()) {
-        return result.getValue();
-      }
-
-      throw new ExecutionException(result.getError());
+    /**
+     * Transforms current future into a successful one regardless of its status, with a {@link Try} to represent
+     * computation status (failure/success).
+     * <p>
+     * ComposableFuture[T](success/failure) => ComposableFuture[Try[T]](success)
+     *
+     * @return a new future of {@link Try[T]}, either Success or Failure depends on computation result.
+     */
+    default ComposableFuture<Try<T>> successful() {
+        return always(__ -> __);
     }
 
-    throw new TimeoutException("Timeout occurred while waiting for a value");
-  }
+    /**
+     * Creates delayed future of current one, by provided duration.
+     * Applied on successful result.
+     *
+     * @param duration duration to delay
+     * @param unit     time unit
+     * @return delayed future
+     */
+    default ComposableFuture<T> delay(final long duration, final TimeUnit unit) {
+        return flatMap(result -> schedule(() -> result, duration, unit));
+    }
 
-  /**
-   * Turns the current future into an eager one.
-   *
-   * @return the new eager future.
-   */
-  ComposableFuture<T> materialize();
+    /**
+     * Ensures that the (successful) result of the current future satisfies the given predicate,
+     * or fails with the given value.
+     *
+     * @param predicate the predicate for the result
+     * @return new future with same value if predicate returns true, else new future with a failure
+     */
+    default ComposableFuture<T> ensure(final Predicate<? super T> predicate) {
+        return flatMap(result -> {
+            if (predicate.test(result)) {
+                return fromValue(result);
+            }
+            return fromError(new NoSuchElementException("predicate is not satisfied"));
+        });
+    }
 
-  /**
-   * Caps the max time for producing a value(or error) for this future.
-   * the returned future will return the original result if available within the specified time or a TimeoutException.
-   *
-   * @param duration max wait time for a result before producing a timeout
-   * @param unit     the duration timeout.
-   * @return the future with a caped time.
-   */
-  ComposableFuture<T> withTimeout(long duration, TimeUnit unit);
+    /**
+     * Consumes the value(or error) of the future into a consumer.
+     * if the future is lazy the value will be reproduced on each consumption.
+     * if the future is eager the consumer will be served from the cached result.
+     *
+     * @param consumer the consumer.
+     */
+    void consume(Consumer<? super T> consumer);
 
-  /**
-   * Caps the max time for producing a value(or error) for this future.
-   * the returned future will return the original result if available within the specified time or a TimeoutException.
-   *
-   * @param scheduler scheduler to schedule timeout on
-   * @param duration  max wait time for a result before producing a timeout
-   * @param unit      the duration timeout.
-   * @return the future with a caped time.
-   */
-  ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit);
+    /**
+     * Blocks until a value is available for consumption and then return it.
+     * in case of an error the exception is wrapped inside an ExecutionException and thrown.
+     * <p>
+     * DO NOT use in non-blocking environment.
+     *
+     * @return the future value if successful
+     * @throws InterruptedException if the thread has been interrupted
+     * @throws ExecutionException   if the future return an error.
+     */
+    default T get() throws InterruptedException, ExecutionException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
+        consume(result -> {
+            resultBox.set(result);
+            latch.countDown();
+        });
 
-  /**
-   * Caps the max time for producing a value(or error) for this future.
-   * the returned future will return the original result if available within the specified time or a TimeoutException.
-   *
-   * @param duration        max wait time for a result before producing a timeout
-   * @param unit            the duration timeout.
-   * @param taskDescription a description that will be added to the timeout error message that will help identify
-   *                        the context of the timeout
-   * @return the future with a caped time.
-   */
-  ComposableFuture<T> withTimeout(long duration, TimeUnit unit, String taskDescription);
+        latch.await();
+        final Try<T> result = resultBox.get();
 
-  /**
-   * Caps the max time for producing a value(or error) for this future.
-   * the returned future will return the original result if available within the specified time or a TimeoutException.
-   *
-   * @param scheduler       scheduler to schedule timeout on
-   * @param duration        max wait time for a result before producing a timeout
-   * @param unit            the duration timeout.
-   * @param taskDescription a description that will be added to the timeout error message that will help identify
-   *                        the context of the timeout
-   * @return the future with a caped time.
-   */
-  ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit, String taskDescription);
+        if (result == null) {
+            throw new ExecutionException(new NullPointerException("no result"));
+        }
+
+        if (result.isSuccess()) {
+            return result.getValue();
+        }
+
+        throw new ExecutionException(result.getError());
+    }
+
+    /**
+     * Blocks until a value is available for consumption or until a timeout occurs, and then return the result or error.
+     * in case of an error the exception is wrapped inside an ExecutionException and thrown.
+     * <p>
+     * DO NOT use in non-blocking environment.
+     *
+     * @param timeout max wait time for result.
+     * @param unit    a time unit for the timeout duration
+     * @return the result if successful
+     * @throws InterruptedException if the thread has been interrupted
+     * @throws ExecutionException   if the future return an error
+     * @throws TimeoutException     if result(or error) haven't arrived in the specified time-span.
+     */
+    default T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
+        consume(result -> {
+            resultBox.set(result);
+            countDownLatch.countDown();
+        });
+
+        if (countDownLatch.await(timeout, unit)) {
+            final Try<T> result = resultBox.get();
+
+            if (result == null) {
+                throw new ExecutionException(new NullPointerException("No result"));
+            }
+
+            if (result.isSuccess()) {
+                return result.getValue();
+            }
+
+            throw new ExecutionException(result.getError());
+        }
+
+        throw new TimeoutException("Timeout occurred while waiting for a value");
+    }
+
+    /**
+     * Turns the current future into an eager one.
+     *
+     * @return the new eager future.
+     */
+    ComposableFuture<T> materialize();
+
+    /**
+     * Caps the max time for producing a value(or error) for this future.
+     * the returned future will return the original result if available within the specified time or a TimeoutException.
+     *
+     * @param duration max wait time for a result before producing a timeout
+     * @param unit     the duration timeout.
+     * @return the future with a caped time.
+     */
+    ComposableFuture<T> withTimeout(long duration, TimeUnit unit);
+
+    /**
+     * Caps the max time for producing a value(or error) for this future.
+     * the returned future will return the original result if available within the specified time or a TimeoutException.
+     *
+     * @param scheduler scheduler to schedule timeout on
+     * @param duration  max wait time for a result before producing a timeout
+     * @param unit      the duration timeout.
+     * @return the future with a caped time.
+     */
+    ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit);
+
+    /**
+     * Caps the max time for producing a value(or error) for this future.
+     * the returned future will return the original result if available within the specified time or a TimeoutException.
+     *
+     * @param duration        max wait time for a result before producing a timeout
+     * @param unit            the duration timeout.
+     * @param taskDescription a description that will be added to the timeout error message that will help identify
+     *                        the context of the timeout
+     * @return the future with a caped time.
+     */
+    ComposableFuture<T> withTimeout(long duration, TimeUnit unit, String taskDescription);
+
+    /**
+     * Caps the max time for producing a value(or error) for this future.
+     * the returned future will return the original result if available within the specified time or a TimeoutException.
+     *
+     * @param scheduler       scheduler to schedule timeout on
+     * @param duration        max wait time for a result before producing a timeout
+     * @param unit            the duration timeout.
+     * @param taskDescription a description that will be added to the timeout error message that will help identify
+     *                        the context of the timeout
+     * @return the future with a caped time.
+     */
+    ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit, String taskDescription);
 
 
 
@@ -302,68 +310,68 @@ public interface ComposableFuture<T> {
    */
 
 
-  /**
-   * Continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
-   *
-   * @param handler the continuation handler that returns a future
-   * @param <R>     the resulting future type.
-   * @return a new future that will produce the result from the handler.
-   */
-  @Deprecated
-  <R> ComposableFuture<R> continueWith(FutureResultHandler<T, R> handler);
+    /**
+     * Continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
+     *
+     * @param handler the continuation handler that returns a future
+     * @param <R>     the resulting future type.
+     * @return a new future that will produce the result from the handler.
+     */
+    @Deprecated
+    <R> ComposableFuture<R> continueWith(FutureResultHandler<T, R> handler);
 
-  /**
-   * continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
-   *
-   * @param handler the continuation handler that returns a value or throws an exception.
-   * @param <R>     the resulting future type.
-   * @return a new future that will produce the result from the handler.
-   */
-  @Deprecated
-  <R> ComposableFuture<R> continueWith(ResultHandler<T, R> handler);
+    /**
+     * continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
+     *
+     * @param handler the continuation handler that returns a value or throws an exception.
+     * @param <R>     the resulting future type.
+     * @return a new future that will produce the result from the handler.
+     */
+    @Deprecated
+    <R> ComposableFuture<R> continueWith(ResultHandler<T, R> handler);
 
-  /**
-   * continues a future with a handler that will be called only if the original future resulted with success
-   * in case of an error the error is continues forward.
-   *
-   * @param handler the continuation handler that returns a future(a.k.a flatMap)
-   * @param <R>     the resulting future type.
-   * @return a new future that will produce the result either from the handler if successful or the original error.
-   */
-  @Deprecated
-  <R> ComposableFuture<R> continueOnSuccess(FutureSuccessHandler<? super T, R> handler);
+    /**
+     * continues a future with a handler that will be called only if the original future resulted with success
+     * in case of an error the error is continues forward.
+     *
+     * @param handler the continuation handler that returns a future(a.k.a flatMap)
+     * @param <R>     the resulting future type.
+     * @return a new future that will produce the result either from the handler if successful or the original error.
+     */
+    @Deprecated
+    <R> ComposableFuture<R> continueOnSuccess(FutureSuccessHandler<? super T, R> handler);
 
-  /**
-   * continues a future with a handler that will be called only if the original future resulted with success
-   * in case of an error the error is continued forward.
-   *
-   * @param handler the continuation handler that returns a future(a.k.a map)
-   * @param <R>     the resulting future type.
-   * @return return a new future that will produce the result either from the handler if successful or the original error.
-   */
-  @Deprecated
-  <R> ComposableFuture<R> continueOnSuccess(SuccessHandler<? super T, ? extends R> handler);
+    /**
+     * continues a future with a handler that will be called only if the original future resulted with success
+     * in case of an error the error is continued forward.
+     *
+     * @param handler the continuation handler that returns a future(a.k.a map)
+     * @param <R>     the resulting future type.
+     * @return return a new future that will produce the result either from the handler if successful or the original error.
+     */
+    @Deprecated
+    <R> ComposableFuture<R> continueOnSuccess(SuccessHandler<? super T, ? extends R> handler);
 
-  /**
-   * continues a future with a handler that will be called only if the original future failed
-   * in case of success the original result is continued forward.
-   *
-   * @param handler the continuation handler that returns a future
-   * @return a new future that will produce the original successful value the the result of the handler.
-   */
-  @Deprecated
-  ComposableFuture<T> continueOnError(FutureErrorHandler<T> handler);
+    /**
+     * continues a future with a handler that will be called only if the original future failed
+     * in case of success the original result is continued forward.
+     *
+     * @param handler the continuation handler that returns a future
+     * @return a new future that will produce the original successful value the the result of the handler.
+     */
+    @Deprecated
+    ComposableFuture<T> continueOnError(FutureErrorHandler<T> handler);
 
-  /**
-   * continues a future with a handler that will be called only if the original future failed
-   * in case of success the original result is continued forward.
-   *
-   * @param handler the continuation handler that returns a value or throws an exception.
-   * @return a new future that will produce the original successful value the the result of the handler.
-   */
-  @Deprecated
-  ComposableFuture<T> continueOnError(ErrorHandler<? extends T> handler);
+    /**
+     * continues a future with a handler that will be called only if the original future failed
+     * in case of success the original result is continued forward.
+     *
+     * @param handler the continuation handler that returns a value or throws an exception.
+     * @return a new future that will produce the original successful value the the result of the handler.
+     */
+    @Deprecated
+    ComposableFuture<T> continueOnError(ErrorHandler<? extends T> handler);
 
-  @Deprecated
-  <R> ComposableFuture<R> transform(com.google.common.base.Function<? super T, ? extends R> function);
+    @Deprecated
+    <R> ComposableFuture<R> transform(com.google.common.base.Function<? super T, ? extends R> function);
 }

--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFuture.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/ComposableFuture.java
@@ -51,252 +51,252 @@ import static com.outbrain.ob1k.concurrent.ComposableFutures.schedule;
  */
 public interface ComposableFuture<T> {
 
-    /**
-     * Continues a future with a handler that will be called only if the original future resulted with success
-     * in case of an error the error is continued forward.
-     *
-     * @param mapper the continuation handler that returns immidiate value
-     * @param <R>    the resulting future type.
-     * @return return a new future that will produce the result either from the handler if successful or the original error.
-     */
-    <R> ComposableFuture<R> map(Function<? super T, ? extends R> mapper);
+  /**
+   * Continues a future with a handler that will be called only if the original future resulted with success
+   * in case of an error the error is continued forward.
+   *
+   * @param mapper the continuation handler that returns immidiate value
+   * @param <R>    the resulting future type.
+   * @return return a new future that will produce the result either from the handler if successful or the original error.
+   */
+  <R> ComposableFuture<R> map(Function<? super T, ? extends R> mapper);
 
-    /**
-     * Continues a future with a handler that will be called only if the original future resulted with success
-     * in case of an error the error is continues forward.
-     *
-     * @param mapper the continuation handler that returns a future
-     * @param <R>    the resulting future type.
-     * @return a new future that will produce the result either from the handler if successful or the original error.
-     */
-    <R> ComposableFuture<R> flatMap(Function<? super T, ? extends ComposableFuture<? extends R>> mapper);
+  /**
+   * Continues a future with a handler that will be called only if the original future resulted with success
+   * in case of an error the error is continues forward.
+   *
+   * @param mapper the continuation handler that returns a future
+   * @param <R>    the resulting future type.
+   * @return a new future that will produce the result either from the handler if successful or the original error.
+   */
+  <R> ComposableFuture<R> flatMap(Function<? super T, ? extends ComposableFuture<? extends R>> mapper);
 
-    /**
-     * Recovers future with a handler that will be called only if the original future failed
-     * in case of success the original result is continued forward.
-     *
-     * @param recover the continuation handler that returns a value or throws an exception.
-     * @return a new future that will produce the original successful value the the result of the handler.
-     */
-    <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, Function<E, ? extends T> recover);
+  /**
+   * Recovers future with a handler that will be called only if the original future failed
+   * in case of success the original result is continued forward.
+   *
+   * @param recover the continuation handler that returns a value or throws an exception.
+   * @return a new future that will produce the original successful value the the result of the handler.
+   */
+  <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, Function<E, ? extends T> recover);
 
-    default ComposableFuture<T> recover(Function<Throwable, ? extends T> recover) {
-        return recover(Throwable.class, recover);
+  default ComposableFuture<T> recover(Function<Throwable, ? extends T> recover) {
+    return recover(Throwable.class, recover);
+  }
+
+  /**
+   * Recovers future with a handler that will be called only if the original future failed
+   * in case of success the original result is continued forward.
+   *
+   * @param recover the continuation handler that returns a future
+   * @return a new future that will produce the original successful value the the result of the handler.
+   */
+  <E extends Throwable> ComposableFuture<T> recoverWith(Class<E> errorType, Function<E, ? extends ComposableFuture<? extends T>> recover);
+
+  default ComposableFuture<T> recoverWith(Function<Throwable, ? extends ComposableFuture<? extends T>> recover) {
+    return recoverWith(Throwable.class, recover);
+  }
+
+  /**
+   * Continues a future with a handler that will be called whether the future has resulted
+   * in a successful value or an error.
+   *
+   * @param handler the continuation handler that returns a value or throws an exception.
+   * @param <R>     the resulting future type.
+   * @return a new future that will produce the result from the handler.
+   */
+  <R> ComposableFuture<R> always(Function<Try<T>, ? extends R> handler);
+
+  /**
+   * Continues a future with a handler that will be called whether the future has resulted
+   * in a successful value or an error.
+   *
+   * @param handler the continuation handler that returns a future
+   * @param <R>     the resulting future type.
+   * @return a new future that will produce the result from the handler.
+   */
+  <R> ComposableFuture<R> alwaysWith(Function<Try<T>, ? extends ComposableFuture<? extends R>> handler);
+
+  /**
+   * Applies the side-effecting function to the result of the current future,
+   * and returns a new future with same value.
+   *
+   * @param consumer the result consumer for the current future result
+   * @return a future with same value
+   */
+  ComposableFuture<T> andThen(Consumer<? super T> consumer);
+
+  /**
+   * Transforms current future into a successful one regardless of its status, with a {@link Try} to represent
+   * computation status (failure/success).
+   * <p>
+   * ComposableFuture[T](success/failure) => ComposableFuture[Try[T]](success)
+   *
+   * @return a new future of {@link Try[T]}, either Success or Failure depends on computation result.
+   */
+  default ComposableFuture<Try<T>> successful() {
+    return always(__ -> __);
+  }
+
+  /**
+   * Creates delayed future of current one, by provided duration.
+   * Applied on successful result.
+   *
+   * @param duration duration to delay
+   * @param unit     time unit
+   * @return delayed future
+   */
+  default ComposableFuture<T> delay(final long duration, final TimeUnit unit) {
+    return flatMap(result -> schedule(() -> result, duration, unit));
+  }
+
+  /**
+   * Ensures that the (successful) result of the current future satisfies the given predicate,
+   * or fails with the given value.
+   *
+   * @param predicate the predicate for the result
+   * @return new future with same value if predicate returns true, else new future with a failure
+   */
+  default ComposableFuture<T> ensure(final Predicate<? super T> predicate) {
+    return flatMap(result -> {
+      if (predicate.test(result)) {
+        return fromValue(result);
+      }
+      return fromError(new NoSuchElementException("predicate is not satisfied"));
+    });
+  }
+
+  /**
+   * Consumes the value(or error) of the future into a consumer.
+   * if the future is lazy the value will be reproduced on each consumption.
+   * if the future is eager the consumer will be served from the cached result.
+   *
+   * @param consumer the consumer.
+   */
+  void consume(Consumer<? super T> consumer);
+
+  /**
+   * Blocks until a value is available for consumption and then return it.
+   * in case of an error the exception is wrapped inside an ExecutionException and thrown.
+   * <p>
+   * DO NOT use in non-blocking environment.
+   *
+   * @return the future value if successful
+   * @throws InterruptedException if the thread has been interrupted
+   * @throws ExecutionException   if the future return an error.
+   */
+  default T get() throws InterruptedException, ExecutionException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
+    consume(result -> {
+      resultBox.set(result);
+      latch.countDown();
+    });
+
+    latch.await();
+    final Try<T> result = resultBox.get();
+
+    if (result == null) {
+      throw new ExecutionException(new NullPointerException("no result"));
     }
 
-    /**
-     * Recovers future with a handler that will be called only if the original future failed
-     * in case of success the original result is continued forward.
-     *
-     * @param recover the continuation handler that returns a future
-     * @return a new future that will produce the original successful value the the result of the handler.
-     */
-    <E extends Throwable> ComposableFuture<T> recoverWith(Class<E> errorType, Function<E, ? extends ComposableFuture<? extends T>> recover);
-
-    default ComposableFuture<T> recoverWith(Function<Throwable, ? extends ComposableFuture<? extends T>> recover) {
-        return recoverWith(Throwable.class, recover);
+    if (result.isSuccess()) {
+      return result.getValue();
     }
 
-    /**
-     * Continues a future with a handler that will be called whether the future has resulted
-     * in a successful value or an error.
-     *
-     * @param handler the continuation handler that returns a value or throws an exception.
-     * @param <R>     the resulting future type.
-     * @return a new future that will produce the result from the handler.
-     */
-    <R> ComposableFuture<R> always(Function<Try<T>, ? extends R> handler);
+    throw new ExecutionException(result.getError());
+  }
 
-    /**
-     * Continues a future with a handler that will be called whether the future has resulted
-     * in a successful value or an error.
-     *
-     * @param handler the continuation handler that returns a future
-     * @param <R>     the resulting future type.
-     * @return a new future that will produce the result from the handler.
-     */
-    <R> ComposableFuture<R> alwaysWith(Function<Try<T>, ? extends ComposableFuture<? extends R>> handler);
+  /**
+   * Blocks until a value is available for consumption or until a timeout occurs, and then return the result or error.
+   * in case of an error the exception is wrapped inside an ExecutionException and thrown.
+   * <p>
+   * DO NOT use in non-blocking environment.
+   *
+   * @param timeout max wait time for result.
+   * @param unit    a time unit for the timeout duration
+   * @return the result if successful
+   * @throws InterruptedException if the thread has been interrupted
+   * @throws ExecutionException   if the future return an error
+   * @throws TimeoutException     if result(or error) haven't arrived in the specified time-span.
+   */
+  default T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
+    consume(result -> {
+      resultBox.set(result);
+      countDownLatch.countDown();
+    });
 
-    /**
-     * Applies the side-effecting function to the result of the current future,
-     * and returns a new future with same value.
-     *
-     * @param consumer the result consumer for the current future result
-     * @return a future with same value
-     */
-    ComposableFuture<T> andThen(Consumer<? super T> consumer);
+    if (countDownLatch.await(timeout, unit)) {
+      final Try<T> result = resultBox.get();
 
-    /**
-     * Transforms current future into a successful one regardless of its status, with a {@link Try} to represent
-     * computation status (failure/success).
-     * <p>
-     * ComposableFuture[T](success/failure) => ComposableFuture[Try[T]](success)
-     *
-     * @return a new future of {@link Try[T]}, either Success or Failure depends on computation result.
-     */
-    default ComposableFuture<Try<T>> successful() {
-        return always(__ -> __);
+      if (result == null) {
+        throw new ExecutionException(new NullPointerException("No result"));
+      }
+
+      if (result.isSuccess()) {
+        return result.getValue();
+      }
+
+      throw new ExecutionException(result.getError());
     }
 
-    /**
-     * Creates delayed future of current one, by provided duration.
-     * Applied on successful result.
-     *
-     * @param duration duration to delay
-     * @param unit     time unit
-     * @return delayed future
-     */
-    default ComposableFuture<T> delay(final long duration, final TimeUnit unit) {
-        return flatMap(result -> schedule(() -> result, duration, unit));
-    }
+    throw new TimeoutException("Timeout occurred while waiting for a value");
+  }
 
-    /**
-     * Ensures that the (successful) result of the current future satisfies the given predicate,
-     * or fails with the given value.
-     *
-     * @param predicate the predicate for the result
-     * @return new future with same value if predicate returns true, else new future with a failure
-     */
-    default ComposableFuture<T> ensure(final Predicate<? super T> predicate) {
-        return flatMap(result -> {
-            if (predicate.test(result)) {
-                return fromValue(result);
-            }
-            return fromError(new NoSuchElementException("predicate is not satisfied"));
-        });
-    }
+  /**
+   * Turns the current future into an eager one.
+   *
+   * @return the new eager future.
+   */
+  ComposableFuture<T> materialize();
 
-    /**
-     * Consumes the value(or error) of the future into a consumer.
-     * if the future is lazy the value will be reproduced on each consumption.
-     * if the future is eager the consumer will be served from the cached result.
-     *
-     * @param consumer the consumer.
-     */
-    void consume(Consumer<? super T> consumer);
+  /**
+   * Caps the max time for producing a value(or error) for this future.
+   * the returned future will return the original result if available within the specified time or a TimeoutException.
+   *
+   * @param duration max wait time for a result before producing a timeout
+   * @param unit     the duration timeout.
+   * @return the future with a caped time.
+   */
+  ComposableFuture<T> withTimeout(long duration, TimeUnit unit);
 
-    /**
-     * Blocks until a value is available for consumption and then return it.
-     * in case of an error the exception is wrapped inside an ExecutionException and thrown.
-     * <p>
-     * DO NOT use in non-blocking environment.
-     *
-     * @return the future value if successful
-     * @throws InterruptedException if the thread has been interrupted
-     * @throws ExecutionException   if the future return an error.
-     */
-    default T get() throws InterruptedException, ExecutionException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
-        consume(result -> {
-            resultBox.set(result);
-            latch.countDown();
-        });
+  /**
+   * Caps the max time for producing a value(or error) for this future.
+   * the returned future will return the original result if available within the specified time or a TimeoutException.
+   *
+   * @param scheduler scheduler to schedule timeout on
+   * @param duration  max wait time for a result before producing a timeout
+   * @param unit      the duration timeout.
+   * @return the future with a caped time.
+   */
+  ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit);
 
-        latch.await();
-        final Try<T> result = resultBox.get();
+  /**
+   * Caps the max time for producing a value(or error) for this future.
+   * the returned future will return the original result if available within the specified time or a TimeoutException.
+   *
+   * @param duration        max wait time for a result before producing a timeout
+   * @param unit            the duration timeout.
+   * @param taskDescription a description that will be added to the timeout error message that will help identify
+   *                        the context of the timeout
+   * @return the future with a caped time.
+   */
+  ComposableFuture<T> withTimeout(long duration, TimeUnit unit, String taskDescription);
 
-        if (result == null) {
-            throw new ExecutionException(new NullPointerException("no result"));
-        }
-
-        if (result.isSuccess()) {
-            return result.getValue();
-        }
-
-        throw new ExecutionException(result.getError());
-    }
-
-    /**
-     * Blocks until a value is available for consumption or until a timeout occurs, and then return the result or error.
-     * in case of an error the exception is wrapped inside an ExecutionException and thrown.
-     * <p>
-     * DO NOT use in non-blocking environment.
-     *
-     * @param timeout max wait time for result.
-     * @param unit    a time unit for the timeout duration
-     * @return the result if successful
-     * @throws InterruptedException if the thread has been interrupted
-     * @throws ExecutionException   if the future return an error
-     * @throws TimeoutException     if result(or error) haven't arrived in the specified time-span.
-     */
-    default T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final AtomicReference<Try<T>> resultBox = new AtomicReference<>();
-        consume(result -> {
-            resultBox.set(result);
-            countDownLatch.countDown();
-        });
-
-        if (countDownLatch.await(timeout, unit)) {
-            final Try<T> result = resultBox.get();
-
-            if (result == null) {
-                throw new ExecutionException(new NullPointerException("No result"));
-            }
-
-            if (result.isSuccess()) {
-                return result.getValue();
-            }
-
-            throw new ExecutionException(result.getError());
-        }
-
-        throw new TimeoutException("Timeout occurred while waiting for a value");
-    }
-
-    /**
-     * Turns the current future into an eager one.
-     *
-     * @return the new eager future.
-     */
-    ComposableFuture<T> materialize();
-
-    /**
-     * Caps the max time for producing a value(or error) for this future.
-     * the returned future will return the original result if available within the specified time or a TimeoutException.
-     *
-     * @param duration max wait time for a result before producing a timeout
-     * @param unit     the duration timeout.
-     * @return the future with a caped time.
-     */
-    ComposableFuture<T> withTimeout(long duration, TimeUnit unit);
-
-    /**
-     * Caps the max time for producing a value(or error) for this future.
-     * the returned future will return the original result if available within the specified time or a TimeoutException.
-     *
-     * @param scheduler scheduler to schedule timeout on
-     * @param duration  max wait time for a result before producing a timeout
-     * @param unit      the duration timeout.
-     * @return the future with a caped time.
-     */
-    ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit);
-
-    /**
-     * Caps the max time for producing a value(or error) for this future.
-     * the returned future will return the original result if available within the specified time or a TimeoutException.
-     *
-     * @param duration        max wait time for a result before producing a timeout
-     * @param unit            the duration timeout.
-     * @param taskDescription a description that will be added to the timeout error message that will help identify
-     *                        the context of the timeout
-     * @return the future with a caped time.
-     */
-    ComposableFuture<T> withTimeout(long duration, TimeUnit unit, String taskDescription);
-
-    /**
-     * Caps the max time for producing a value(or error) for this future.
-     * the returned future will return the original result if available within the specified time or a TimeoutException.
-     *
-     * @param scheduler       scheduler to schedule timeout on
-     * @param duration        max wait time for a result before producing a timeout
-     * @param unit            the duration timeout.
-     * @param taskDescription a description that will be added to the timeout error message that will help identify
-     *                        the context of the timeout
-     * @return the future with a caped time.
-     */
-    ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit, String taskDescription);
+  /**
+   * Caps the max time for producing a value(or error) for this future.
+   * the returned future will return the original result if available within the specified time or a TimeoutException.
+   *
+   * @param scheduler       scheduler to schedule timeout on
+   * @param duration        max wait time for a result before producing a timeout
+   * @param unit            the duration timeout.
+   * @param taskDescription a description that will be added to the timeout error message that will help identify
+   *                        the context of the timeout
+   * @return the future with a caped time.
+   */
+  ComposableFuture<T> withTimeout(Scheduler scheduler, long duration, TimeUnit unit, String taskDescription);
 
 
 
@@ -310,68 +310,68 @@ public interface ComposableFuture<T> {
    */
 
 
-    /**
-     * Continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
-     *
-     * @param handler the continuation handler that returns a future
-     * @param <R>     the resulting future type.
-     * @return a new future that will produce the result from the handler.
-     */
-    @Deprecated
-    <R> ComposableFuture<R> continueWith(FutureResultHandler<T, R> handler);
+  /**
+   * Continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
+   *
+   * @param handler the continuation handler that returns a future
+   * @param <R>     the resulting future type.
+   * @return a new future that will produce the result from the handler.
+   */
+  @Deprecated
+  <R> ComposableFuture<R> continueWith(FutureResultHandler<T, R> handler);
 
-    /**
-     * continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
-     *
-     * @param handler the continuation handler that returns a value or throws an exception.
-     * @param <R>     the resulting future type.
-     * @return a new future that will produce the result from the handler.
-     */
-    @Deprecated
-    <R> ComposableFuture<R> continueWith(ResultHandler<T, R> handler);
+  /**
+   * continues a future with a handler that will be called whether the future has resulted in a successful value or an error.
+   *
+   * @param handler the continuation handler that returns a value or throws an exception.
+   * @param <R>     the resulting future type.
+   * @return a new future that will produce the result from the handler.
+   */
+  @Deprecated
+  <R> ComposableFuture<R> continueWith(ResultHandler<T, R> handler);
 
-    /**
-     * continues a future with a handler that will be called only if the original future resulted with success
-     * in case of an error the error is continues forward.
-     *
-     * @param handler the continuation handler that returns a future(a.k.a flatMap)
-     * @param <R>     the resulting future type.
-     * @return a new future that will produce the result either from the handler if successful or the original error.
-     */
-    @Deprecated
-    <R> ComposableFuture<R> continueOnSuccess(FutureSuccessHandler<? super T, R> handler);
+  /**
+   * continues a future with a handler that will be called only if the original future resulted with success
+   * in case of an error the error is continues forward.
+   *
+   * @param handler the continuation handler that returns a future(a.k.a flatMap)
+   * @param <R>     the resulting future type.
+   * @return a new future that will produce the result either from the handler if successful or the original error.
+   */
+  @Deprecated
+  <R> ComposableFuture<R> continueOnSuccess(FutureSuccessHandler<? super T, R> handler);
 
-    /**
-     * continues a future with a handler that will be called only if the original future resulted with success
-     * in case of an error the error is continued forward.
-     *
-     * @param handler the continuation handler that returns a future(a.k.a map)
-     * @param <R>     the resulting future type.
-     * @return return a new future that will produce the result either from the handler if successful or the original error.
-     */
-    @Deprecated
-    <R> ComposableFuture<R> continueOnSuccess(SuccessHandler<? super T, ? extends R> handler);
+  /**
+   * continues a future with a handler that will be called only if the original future resulted with success
+   * in case of an error the error is continued forward.
+   *
+   * @param handler the continuation handler that returns a future(a.k.a map)
+   * @param <R>     the resulting future type.
+   * @return return a new future that will produce the result either from the handler if successful or the original error.
+   */
+  @Deprecated
+  <R> ComposableFuture<R> continueOnSuccess(SuccessHandler<? super T, ? extends R> handler);
 
-    /**
-     * continues a future with a handler that will be called only if the original future failed
-     * in case of success the original result is continued forward.
-     *
-     * @param handler the continuation handler that returns a future
-     * @return a new future that will produce the original successful value the the result of the handler.
-     */
-    @Deprecated
-    ComposableFuture<T> continueOnError(FutureErrorHandler<T> handler);
+  /**
+   * continues a future with a handler that will be called only if the original future failed
+   * in case of success the original result is continued forward.
+   *
+   * @param handler the continuation handler that returns a future
+   * @return a new future that will produce the original successful value the the result of the handler.
+   */
+  @Deprecated
+  ComposableFuture<T> continueOnError(FutureErrorHandler<T> handler);
 
-    /**
-     * continues a future with a handler that will be called only if the original future failed
-     * in case of success the original result is continued forward.
-     *
-     * @param handler the continuation handler that returns a value or throws an exception.
-     * @return a new future that will produce the original successful value the the result of the handler.
-     */
-    @Deprecated
-    ComposableFuture<T> continueOnError(ErrorHandler<? extends T> handler);
+  /**
+   * continues a future with a handler that will be called only if the original future failed
+   * in case of success the original result is continued forward.
+   *
+   * @param handler the continuation handler that returns a value or throws an exception.
+   * @return a new future that will produce the original successful value the the result of the handler.
+   */
+  @Deprecated
+  ComposableFuture<T> continueOnError(ErrorHandler<? extends T> handler);
 
-    @Deprecated
-    <R> ComposableFuture<R> transform(com.google.common.base.Function<? super T, ? extends R> function);
+  @Deprecated
+  <R> ComposableFuture<R> transform(com.google.common.base.Function<? super T, ? extends R> function);
 }

--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/eager/EagerComposableFuture.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/eager/EagerComposableFuture.java
@@ -1,29 +1,12 @@
 package com.outbrain.ob1k.concurrent.eager;
 
-import com.outbrain.ob1k.concurrent.CancellationToken;
-import com.outbrain.ob1k.concurrent.ComposableFuture;
-import com.outbrain.ob1k.concurrent.ComposableFutures;
-import com.outbrain.ob1k.concurrent.Consumer;
-import com.outbrain.ob1k.concurrent.Producer;
-import com.outbrain.ob1k.concurrent.Scheduler;
-import com.outbrain.ob1k.concurrent.Try;
-import com.outbrain.ob1k.concurrent.UncheckedExecutionException;
-import com.outbrain.ob1k.concurrent.handlers.ErrorHandler;
-import com.outbrain.ob1k.concurrent.handlers.FutureAction;
-import com.outbrain.ob1k.concurrent.handlers.FutureErrorHandler;
-import com.outbrain.ob1k.concurrent.handlers.FutureResultHandler;
-import com.outbrain.ob1k.concurrent.handlers.FutureSuccessHandler;
-import com.outbrain.ob1k.concurrent.handlers.ResultHandler;
-import com.outbrain.ob1k.concurrent.handlers.SuccessHandler;
+import com.outbrain.ob1k.concurrent.*;
+import com.outbrain.ob1k.concurrent.handlers.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -38,395 +21,410 @@ import static java.util.function.Function.identity;
  */
 public final class EagerComposableFuture<T> implements ComposableFuture<T>, ComposablePromise<T> {
 
-  private static final Logger logger = LoggerFactory.getLogger(EagerComposableFuture.class);
+    private static final Logger logger = LoggerFactory.getLogger(EagerComposableFuture.class);
 
-  private final Executor threadPool;
-  private final HandlersList handlers;
-  private final AtomicReference<Try<T>> value = new AtomicReference<>();
+    private final Executor threadPool;
+    private final HandlersList handlers;
+    private final AtomicReference<Try<T>> value = new AtomicReference<>();
 
-  public EagerComposableFuture() {
-    threadPool = null;
-    handlers = new HandlersList();
-  }
+    public EagerComposableFuture() {
+        threadPool = null;
+        handlers = new HandlersList();
+    }
 
-  public EagerComposableFuture(final Executor threadPool) {
-    this.threadPool = threadPool;
-    handlers = new HandlersList();
-  }
+    public EagerComposableFuture(final Executor threadPool) {
+        this.threadPool = threadPool;
+        handlers = new HandlersList();
+    }
 
-  public static <T> ComposableFuture<T> fromValue(final T value) {
-    final EagerComposableFuture<T> result = new EagerComposableFuture<>();
-    result.set(value);
-    return result;
-  }
+    public static <T> ComposableFuture<T> fromValue(final T value) {
+        final EagerComposableFuture<T> result = new EagerComposableFuture<>();
+        result.set(value);
+        return result;
+    }
 
-  public static <T> ComposableFuture<T> fromError(final Throwable error) {
-    final EagerComposableFuture<T> result = new EagerComposableFuture<>();
-    result.setException(error);
-    return result;
-  }
+    public static <T> ComposableFuture<T> fromError(final Throwable error) {
+        final EagerComposableFuture<T> result = new EagerComposableFuture<>();
+        result.setException(error);
+        return result;
+    }
 
-  public static <T> ComposableFuture<T> build(final Producer<? extends T> producer) {
-    final EagerComposableFuture<T> future = new EagerComposableFuture<>();
-    producer.produce(result -> {
-      if (result.isSuccess()) {
-        future.set(result.getValue());
-      } else {
-        future.setException(result.getError());
-      }
-    });
-
-    return future;
-  }
-
-  public static <T> ComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
-    if (task == null)
-      return fromError(new NullPointerException("task must not be null"));
-
-    final EagerComposableFuture<T> future = delegateHandler ?
-      new EagerComposableFuture<>(executor) :
-      new EagerComposableFuture<>();
-
-    executor.execute(() -> future.setTry(Try.apply(task::call)));
-    return future;
-  }
-
-  public static <T> ComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit unit) {
-    final EagerComposableFuture<T> future = new EagerComposableFuture<>();
-    scheduler.schedule(() -> future.setTry(Try.apply(task::call)), delay, unit);
-    return future;
-  }
-
-  public static <T> ComposableFuture<T> doubleDispatch(final FutureAction<T> action, final long duration,
-                                                       final TimeUnit unit, final Scheduler scheduler) {
-    final ComposableFuture<T> first = action.execute();
-    final AtomicBoolean done = new AtomicBoolean();
-
-    first.consume(result -> done.compareAndSet(false, true));
-
-    final EagerComposableFuture<T> second = new EagerComposableFuture<>();
-    scheduler.schedule(() -> {
-      if (done.compareAndSet(false, true)) {
-        try {
-          final ComposableFuture<T> innerSecond = action.execute();
-          innerSecond.consume(result -> {
+    public static <T> ComposableFuture<T> build(final Producer<? extends T> producer) {
+        final EagerComposableFuture<T> future = new EagerComposableFuture<>();
+        producer.produce(result -> {
             if (result.isSuccess()) {
-              second.set(result.getValue());
+                future.set(result.getValue());
             } else {
-              second.setException(result.getError());
+                future.setException(result.getError());
             }
-          });
-        } catch (final Throwable e) {
-          second.setException(e);
-        }
-      }
-    }, duration, unit);
+        });
 
-    return collectFirst(asList(first, second));
-  }
-
-  public static <T> ComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
-    final int size = futures.size();
-    if (size == 0) {
-      return fromError(new IllegalArgumentException("empty future list"));
+        return future;
     }
 
-    final EagerComposableFuture<T> res = new EagerComposableFuture<>();
-    final AtomicBoolean done = new AtomicBoolean();
+    public static <T> ComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
+        if (task == null)
+            return fromError(new NullPointerException("task must not be null"));
 
-    for (final ComposableFuture<T> future : futures) {
-      future.consume(result -> {
-        if (done.compareAndSet(false, true)) {
-          if (result.isSuccess()) {
-            res.set(result.getValue());
-          } else {
-            res.setException(result.getError());
-          }
-        }
-      });
+        final EagerComposableFuture<T> future = delegateHandler ?
+                new EagerComposableFuture<>(executor) :
+                new EagerComposableFuture<>();
+
+        executor.execute(() -> future.setTry(Try.apply(task::call)));
+        return future;
     }
 
-    return res;
-  }
-
-  @Override
-  public void setTry(final Try<? extends T> value) {
-    if (value.isSuccess()) {
-      set(value.getValue());
-    } else {
-      setException(value.getError());
+    public static <T> ComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit unit) {
+        final EagerComposableFuture<T> future = new EagerComposableFuture<>();
+        scheduler.schedule(() -> future.setTry(Try.apply(task::call)), delay, unit);
+        return future;
     }
-  }
 
-  @Override
-  public void set(final T result) {
-    if (value.compareAndSet(null, Try.fromValue(result))) {
-      done();
+    public static <T> ComposableFuture<T> doubleDispatch(final FutureAction<T> action, final long duration,
+                                                         final TimeUnit unit, final Scheduler scheduler) {
+        final ComposableFuture<T> first = action.execute();
+        final AtomicBoolean done = new AtomicBoolean();
+
+        first.consume(result -> done.compareAndSet(false, true));
+
+        final EagerComposableFuture<T> second = new EagerComposableFuture<>();
+        scheduler.schedule(() -> {
+            if (done.compareAndSet(false, true)) {
+                try {
+                    final ComposableFuture<T> innerSecond = action.execute();
+                    innerSecond.consume(result -> {
+                        if (result.isSuccess()) {
+                            second.set(result.getValue());
+                        } else {
+                            second.setException(result.getError());
+                        }
+                    });
+                } catch (final Throwable e) {
+                    second.setException(e);
+                }
+            }
+        }, duration, unit);
+
+        return collectFirst(asList(first, second));
     }
-  }
 
-  @Override
-  public void setException(final Throwable t) {
-    if (value.compareAndSet(null, Try.fromError(t))) {
-      done();
+    public static <T> ComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
+        final int size = futures.size();
+        if (size == 0) {
+            return fromError(new IllegalArgumentException("empty future list"));
+        }
+
+        final EagerComposableFuture<T> res = new EagerComposableFuture<>();
+        final AtomicBoolean done = new AtomicBoolean();
+
+        for (final ComposableFuture<T> future : futures) {
+            future.consume(result -> {
+                if (done.compareAndSet(false, true)) {
+                    if (result.isSuccess()) {
+                        res.set(result.getValue());
+                    } else {
+                        res.setException(result.getError());
+                    }
+                }
+            });
+        }
+
+        return res;
     }
-  }
 
-  @Override
-  public ComposableFuture<T> future() {
-    return this;
-  }
-
-  private void done() {
-    handlers.execute(threadPool);
-  }
-
-  @Override
-  public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> handler) {
-    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-    this.consume(result -> {
-      if (result.isSuccess()) {
-        try {
-          future.set(handler.apply(result.getValue()));
-        } catch (final UncheckedExecutionException e) {
-          future.setException(e.getCause() != null ? e.getCause() : e);
-        } catch (final Throwable e) {
-          future.setException(e);
+    @Override
+    public void setTry(final Try<? extends T> value) {
+        if (value.isSuccess()) {
+            set(value.getValue());
+        } else {
+            setException(value.getError());
         }
-      } else {
-        future.setException(result.getError());
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> handler) {
-    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-    this.consume(result -> {
-      if (result.isSuccess()) {
-        try {
-          final ComposableFuture<? extends R> res = handler.apply(result.getValue());
-          consumeFrom(future, res);
-        } catch (final Throwable e) {
-          future.setException(e);
-        }
-      } else {
-        future.setException(result.getError());
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public ComposableFuture<T> recover(final Function<Throwable, ? extends T> handler) {
-    final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
-    this.consume(result -> {
-      if (result.isSuccess()) {
-        future.set(result.getValue());
-      } else {
-        try {
-          future.set(handler.apply(result.getError()));
-        } catch (final UncheckedExecutionException e) {
-          future.setException(e.getCause() != null ? e.getCause() : e);
-        } catch (final Throwable e) {
-          future.setException(e);
-        }
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public ComposableFuture<T> recoverWith(final Function<Throwable, ? extends ComposableFuture<? extends T>> handler) {
-    final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
-    this.consume(result -> {
-      if (result.isSuccess()) {
-        future.set(result.getValue());
-      } else {
-        try {
-          final ComposableFuture<? extends T> res = handler.apply(result.getError());
-          consumeFrom(future, res);
-        } catch (final Throwable e) {
-          future.setException(e);
-        }
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
-    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-    this.consume(res -> {
-      try {
-        future.set(handler.apply(res));
-      } catch (final UncheckedExecutionException e) {
-        future.setException(e.getCause() != null ? e.getCause() : e);
-      } catch (final Throwable e) {
-        future.setException(e);
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
-    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-    this.consume(res -> {
-      try {
-        final ComposableFuture<? extends R> nextResult = handler.apply(res);
-        consumeFrom(future, nextResult);
-      } catch (final Throwable e) {
-        future.setException(e);
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
-    final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
-    this.consume(result -> {
-      try {
-        resultConsumer.consume(result.map(identity()));
-      } finally {
-        future.setTry(result);
-      }
-    });
-
-    return future;
-  }
-
-  @Override
-  public void consume(final Consumer<? super T> consumer) {
-    handlers.addHandler(new ConsumerAction<>(consumer, this), threadPool);
-  }
-
-  @Override
-  public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit, final String taskDescription) {
-    return withTimeout(ComposableFutures.getScheduler(), duration, unit, taskDescription);
-  }
-
-  @Override
-  public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit, final String taskDescription) {
-    final ComposablePromise<T> deadline = new EagerComposableFuture<>();
-    final CancellationToken cancellationToken = scheduler.schedule(() ->
-      deadline.setException(new TimeoutException("Timeout occurred on task ('" + taskDescription + "' " + timeout + " " + unit + ")")), timeout, unit);
-
-    this.consume(result -> cancellationToken.cancel(false));
-    return collectFirst(asList(this, deadline.future()));
-  }
-
-  @Override
-  public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit) {
-    return withTimeout(ComposableFutures.getScheduler(), duration, unit);
-  }
-
-  @Override
-  public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
-    return withTimeout(scheduler, timeout, unit, "unspecified task");
-  }
-
-  @Override
-  public ComposableFuture<T> materialize() {
-    return this;
-  }
-
-  private <R> void consumeFrom(final ComposablePromise<R> promise, final ComposableFuture<? extends R> future) {
-    if (future == null) {
-      promise.set(null);
-    } else {
-      future.consume(promise::setTry);
     }
-  }
+
+    @Override
+    public void set(final T result) {
+        if (value.compareAndSet(null, Try.fromValue(result))) {
+            done();
+        }
+    }
+
+    @Override
+    public void setException(final Throwable t) {
+        if (value.compareAndSet(null, Try.fromError(t))) {
+            done();
+        }
+    }
+
+    @Override
+    public ComposableFuture<T> future() {
+        return this;
+    }
+
+    private void done() {
+        handlers.execute(threadPool);
+    }
+
+    @Override
+    public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> handler) {
+        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+        this.consume(result -> {
+            if (result.isSuccess()) {
+                try {
+                    future.set(handler.apply(result.getValue()));
+                } catch (final UncheckedExecutionException e) {
+                    future.setException(e.getCause() != null ? e.getCause() : e);
+                } catch (final Throwable e) {
+                    future.setException(e);
+                }
+            } else {
+                future.setException(result.getError());
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> handler) {
+        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+        this.consume(result -> {
+            if (result.isSuccess()) {
+                try {
+                    final ComposableFuture<? extends R> res = handler.apply(result.getValue());
+                    consumeFrom(future, res);
+                } catch (final Throwable e) {
+                    future.setException(e);
+                }
+            } else {
+                future.setException(result.getError());
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, final Function<E, ? extends T> handler) {
+        final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
+        this.consume(result -> {
+            if (result.isSuccess()) {
+                future.set(result.getValue());
+            } else {
+                try {
+                    Throwable error = result.getError();
+                    if (errorType.isInstance(error)) {
+                        E matchingError = errorType.cast(error);
+                        future.set(handler.apply(matchingError));
+                    } else {
+                        future.setException(error);
+                    }
+                } catch (final UncheckedExecutionException e) {
+                    future.setException(e.getCause() != null ? e.getCause() : e);
+                } catch (final Throwable e) {
+                    future.setException(e);
+                }
+            }
+        });
+
+        return future;
+
+    }
+
+    @Override
+    public <E extends Throwable> ComposableFuture<T>
+        recoverWith(Class<E> errorType, final Function<E, ? extends ComposableFuture<? extends T>> handler) {
+
+        final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
+        this.consume(result -> {
+            if (result.isSuccess()) {
+                future.set(result.getValue());
+            } else {
+                try {
+                    Throwable error = result.getError();
+                    if (errorType.isInstance(error)) {
+                        E matchedError = errorType.cast(error);
+                        final ComposableFuture<? extends T> res = handler.apply(matchedError);
+                        consumeFrom(future, res);
+                    } else {
+                        future.setException(error);
+                    }
+                } catch (final Throwable e) {
+                    future.setException(e);
+                }
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
+        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+        this.consume(res -> {
+            try {
+                future.set(handler.apply(res));
+            } catch (final UncheckedExecutionException e) {
+                future.setException(e.getCause() != null ? e.getCause() : e);
+            } catch (final Throwable e) {
+                future.setException(e);
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
+        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+        this.consume(res -> {
+            try {
+                final ComposableFuture<? extends R> nextResult = handler.apply(res);
+                consumeFrom(future, nextResult);
+            } catch (final Throwable e) {
+                future.setException(e);
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
+        final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
+        this.consume(result -> {
+            try {
+                resultConsumer.consume(result.map(identity()));
+            } finally {
+                future.setTry(result);
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public void consume(final Consumer<? super T> consumer) {
+        handlers.addHandler(new ConsumerAction<>(consumer, this), threadPool);
+    }
+
+    @Override
+    public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit, final String taskDescription) {
+        return withTimeout(ComposableFutures.getScheduler(), duration, unit, taskDescription);
+    }
+
+    @Override
+    public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit, final String taskDescription) {
+        final ComposablePromise<T> deadline = new EagerComposableFuture<>();
+        final CancellationToken cancellationToken = scheduler.schedule(() ->
+                deadline.setException(new TimeoutException("Timeout occurred on task ('" + taskDescription + "' " + timeout + " " + unit + ")")), timeout, unit);
+
+        this.consume(result -> cancellationToken.cancel(false));
+        return collectFirst(asList(this, deadline.future()));
+    }
+
+    @Override
+    public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit) {
+        return withTimeout(ComposableFutures.getScheduler(), duration, unit);
+    }
+
+    @Override
+    public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
+        return withTimeout(scheduler, timeout, unit, "unspecified task");
+    }
+
+    @Override
+    public ComposableFuture<T> materialize() {
+        return this;
+    }
+
+    private <R> void consumeFrom(final ComposablePromise<R> promise, final ComposableFuture<? extends R> future) {
+        if (future == null) {
+            promise.set(null);
+        } else {
+            future.consume(promise::setTry);
+        }
+    }
 
   /*
     OLD API - DEPRECATED
  */
 
 
-  @Override
-  @SuppressWarnings({"unchecked", "deprecated"})
-  public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
-    return alwaysWith(handler::handle);
-  }
-
-  @Override
-  @SuppressWarnings({"unchecked", "deprecated"})
-  public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
-    return always(result -> {
-      try {
-        return handler.handle(result);
-      } catch (final ExecutionException e) {
-        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-        throw new UncheckedExecutionException(e);
-      }
-    });
-  }
-
-  @Override
-  public <R> ComposableFuture<R> continueOnSuccess(final FutureSuccessHandler<? super T, R> handler) {
-    return flatMap(handler::handle); // sweet
-  }
-
-  @Override
-  public <R> ComposableFuture<R> continueOnSuccess(final SuccessHandler<? super T, ? extends R> handler) {
-    return map(result -> {
-      try {
-        return handler.handle(result);
-      } catch (final ExecutionException e) {
-        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-        throw new UncheckedExecutionException(e.getCause());
-      }
-    });
-  }
-
-  @Override
-  public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
-    return recoverWith(handler::handle);
-  }
-
-  @Override
-  public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
-    return recover(error -> {
-      try {
-        return handler.handle(error);
-      } catch (final ExecutionException e) {
-        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-        throw new UncheckedExecutionException(e.getCause());
-      }
-    });
-  }
-
-  @Override
-  public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
-    return map(function::apply);
-  }
-
-  private static class ConsumerAction<T> implements Runnable {
-    final Consumer<? super T> inner;
-    final EagerComposableFuture<T> current;
-
-    private ConsumerAction(final Consumer<? super T> inner, final EagerComposableFuture<T> current) {
-      this.inner = inner;
-      this.current = current;
+    @Override
+    @SuppressWarnings({"unchecked", "deprecated"})
+    public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
+        return alwaysWith(handler::handle);
     }
 
     @Override
-    public void run() {
-      try {
-        final Try<T> currentValue = current.value.get();
-        inner.consume(currentValue.map(identity()));
-      } catch (final Throwable error) {
-        logger.warn("error while handling future callbacks", error);
-      }
+    @SuppressWarnings({"unchecked", "deprecated"})
+    public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
+        return always(result -> {
+            try {
+                return handler.handle(result);
+            } catch (final ExecutionException e) {
+                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+                throw new UncheckedExecutionException(e);
+            }
+        });
     }
-  }
+
+    @Override
+    public <R> ComposableFuture<R> continueOnSuccess(final FutureSuccessHandler<? super T, R> handler) {
+        return flatMap(handler::handle); // sweet
+    }
+
+    @Override
+    public <R> ComposableFuture<R> continueOnSuccess(final SuccessHandler<? super T, ? extends R> handler) {
+        return map(result -> {
+            try {
+                return handler.handle(result);
+            } catch (final ExecutionException e) {
+                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+                throw new UncheckedExecutionException(e.getCause());
+            }
+        });
+    }
+
+    @Override
+    public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
+        return recoverWith(handler::handle);
+    }
+
+    @Override
+    public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
+        return recover(error -> {
+            try {
+                return handler.handle(error);
+            } catch (final ExecutionException e) {
+                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+                throw new UncheckedExecutionException(e.getCause());
+            }
+        });
+    }
+
+    @Override
+    public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
+        return map(function::apply);
+    }
+
+    private static class ConsumerAction<T> implements Runnable {
+        final Consumer<? super T> inner;
+        final EagerComposableFuture<T> current;
+
+        private ConsumerAction(final Consumer<? super T> inner, final EagerComposableFuture<T> current) {
+            this.inner = inner;
+            this.current = current;
+        }
+
+        @Override
+        public void run() {
+            try {
+                final Try<T> currentValue = current.value.get();
+                inner.consume(currentValue.map(identity()));
+            } catch (final Throwable error) {
+                logger.warn("error while handling future callbacks", error);
+            }
+        }
+    }
 }

--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/eager/EagerComposableFuture.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/eager/EagerComposableFuture.java
@@ -21,410 +21,410 @@ import static java.util.function.Function.identity;
  */
 public final class EagerComposableFuture<T> implements ComposableFuture<T>, ComposablePromise<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(EagerComposableFuture.class);
+  private static final Logger logger = LoggerFactory.getLogger(EagerComposableFuture.class);
 
-    private final Executor threadPool;
-    private final HandlersList handlers;
-    private final AtomicReference<Try<T>> value = new AtomicReference<>();
+  private final Executor threadPool;
+  private final HandlersList handlers;
+  private final AtomicReference<Try<T>> value = new AtomicReference<>();
 
-    public EagerComposableFuture() {
-        threadPool = null;
-        handlers = new HandlersList();
-    }
+  public EagerComposableFuture() {
+    threadPool = null;
+    handlers = new HandlersList();
+  }
 
-    public EagerComposableFuture(final Executor threadPool) {
-        this.threadPool = threadPool;
-        handlers = new HandlersList();
-    }
+  public EagerComposableFuture(final Executor threadPool) {
+    this.threadPool = threadPool;
+    handlers = new HandlersList();
+  }
 
-    public static <T> ComposableFuture<T> fromValue(final T value) {
-        final EagerComposableFuture<T> result = new EagerComposableFuture<>();
-        result.set(value);
-        return result;
-    }
+  public static <T> ComposableFuture<T> fromValue(final T value) {
+    final EagerComposableFuture<T> result = new EagerComposableFuture<>();
+    result.set(value);
+    return result;
+  }
 
-    public static <T> ComposableFuture<T> fromError(final Throwable error) {
-        final EagerComposableFuture<T> result = new EagerComposableFuture<>();
-        result.setException(error);
-        return result;
-    }
+  public static <T> ComposableFuture<T> fromError(final Throwable error) {
+    final EagerComposableFuture<T> result = new EagerComposableFuture<>();
+    result.setException(error);
+    return result;
+  }
 
-    public static <T> ComposableFuture<T> build(final Producer<? extends T> producer) {
-        final EagerComposableFuture<T> future = new EagerComposableFuture<>();
-        producer.produce(result -> {
+  public static <T> ComposableFuture<T> build(final Producer<? extends T> producer) {
+    final EagerComposableFuture<T> future = new EagerComposableFuture<>();
+    producer.produce(result -> {
+      if (result.isSuccess()) {
+        future.set(result.getValue());
+      } else {
+        future.setException(result.getError());
+      }
+    });
+
+    return future;
+  }
+
+  public static <T> ComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
+    if (task == null)
+      return fromError(new NullPointerException("task must not be null"));
+
+    final EagerComposableFuture<T> future = delegateHandler ?
+        new EagerComposableFuture<>(executor) :
+        new EagerComposableFuture<>();
+
+    executor.execute(() -> future.setTry(Try.apply(task::call)));
+    return future;
+  }
+
+  public static <T> ComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit unit) {
+    final EagerComposableFuture<T> future = new EagerComposableFuture<>();
+    scheduler.schedule(() -> future.setTry(Try.apply(task::call)), delay, unit);
+    return future;
+  }
+
+  public static <T> ComposableFuture<T> doubleDispatch(final FutureAction<T> action, final long duration,
+                                                       final TimeUnit unit, final Scheduler scheduler) {
+    final ComposableFuture<T> first = action.execute();
+    final AtomicBoolean done = new AtomicBoolean();
+
+    first.consume(result -> done.compareAndSet(false, true));
+
+    final EagerComposableFuture<T> second = new EagerComposableFuture<>();
+    scheduler.schedule(() -> {
+      if (done.compareAndSet(false, true)) {
+        try {
+          final ComposableFuture<T> innerSecond = action.execute();
+          innerSecond.consume(result -> {
             if (result.isSuccess()) {
-                future.set(result.getValue());
+              second.set(result.getValue());
             } else {
-                future.setException(result.getError());
+              second.setException(result.getError());
             }
-        });
-
-        return future;
-    }
-
-    public static <T> ComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
-        if (task == null)
-            return fromError(new NullPointerException("task must not be null"));
-
-        final EagerComposableFuture<T> future = delegateHandler ?
-                new EagerComposableFuture<>(executor) :
-                new EagerComposableFuture<>();
-
-        executor.execute(() -> future.setTry(Try.apply(task::call)));
-        return future;
-    }
-
-    public static <T> ComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit unit) {
-        final EagerComposableFuture<T> future = new EagerComposableFuture<>();
-        scheduler.schedule(() -> future.setTry(Try.apply(task::call)), delay, unit);
-        return future;
-    }
-
-    public static <T> ComposableFuture<T> doubleDispatch(final FutureAction<T> action, final long duration,
-                                                         final TimeUnit unit, final Scheduler scheduler) {
-        final ComposableFuture<T> first = action.execute();
-        final AtomicBoolean done = new AtomicBoolean();
-
-        first.consume(result -> done.compareAndSet(false, true));
-
-        final EagerComposableFuture<T> second = new EagerComposableFuture<>();
-        scheduler.schedule(() -> {
-            if (done.compareAndSet(false, true)) {
-                try {
-                    final ComposableFuture<T> innerSecond = action.execute();
-                    innerSecond.consume(result -> {
-                        if (result.isSuccess()) {
-                            second.set(result.getValue());
-                        } else {
-                            second.setException(result.getError());
-                        }
-                    });
-                } catch (final Throwable e) {
-                    second.setException(e);
-                }
-            }
-        }, duration, unit);
-
-        return collectFirst(asList(first, second));
-    }
-
-    public static <T> ComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
-        final int size = futures.size();
-        if (size == 0) {
-            return fromError(new IllegalArgumentException("empty future list"));
+          });
+        } catch (final Throwable e) {
+          second.setException(e);
         }
+      }
+    }, duration, unit);
 
-        final EagerComposableFuture<T> res = new EagerComposableFuture<>();
-        final AtomicBoolean done = new AtomicBoolean();
+    return collectFirst(asList(first, second));
+  }
 
-        for (final ComposableFuture<T> future : futures) {
-            future.consume(result -> {
-                if (done.compareAndSet(false, true)) {
-                    if (result.isSuccess()) {
-                        res.set(result.getValue());
-                    } else {
-                        res.setException(result.getError());
-                    }
-                }
-            });
+  public static <T> ComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
+    final int size = futures.size();
+    if (size == 0) {
+      return fromError(new IllegalArgumentException("empty future list"));
+    }
+
+    final EagerComposableFuture<T> res = new EagerComposableFuture<>();
+    final AtomicBoolean done = new AtomicBoolean();
+
+    for (final ComposableFuture<T> future : futures) {
+      future.consume(result -> {
+        if (done.compareAndSet(false, true)) {
+          if (result.isSuccess()) {
+            res.set(result.getValue());
+          } else {
+            res.setException(result.getError());
+          }
         }
-
-        return res;
+      });
     }
 
-    @Override
-    public void setTry(final Try<? extends T> value) {
-        if (value.isSuccess()) {
-            set(value.getValue());
-        } else {
-            setException(value.getError());
+    return res;
+  }
+
+  @Override
+  public void setTry(final Try<? extends T> value) {
+    if (value.isSuccess()) {
+      set(value.getValue());
+    } else {
+      setException(value.getError());
+    }
+  }
+
+  @Override
+  public void set(final T result) {
+    if (value.compareAndSet(null, Try.fromValue(result))) {
+      done();
+    }
+  }
+
+  @Override
+  public void setException(final Throwable t) {
+    if (value.compareAndSet(null, Try.fromError(t))) {
+      done();
+    }
+  }
+
+  @Override
+  public ComposableFuture<T> future() {
+    return this;
+  }
+
+  private void done() {
+    handlers.execute(threadPool);
+  }
+
+  @Override
+  public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> handler) {
+    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+    this.consume(result -> {
+      if (result.isSuccess()) {
+        try {
+          future.set(handler.apply(result.getValue()));
+        } catch (final UncheckedExecutionException e) {
+          future.setException(e.getCause() != null ? e.getCause() : e);
+        } catch (final Throwable e) {
+          future.setException(e);
         }
-    }
+      } else {
+        future.setException(result.getError());
+      }
+    });
 
-    @Override
-    public void set(final T result) {
-        if (value.compareAndSet(null, Try.fromValue(result))) {
-            done();
+    return future;
+  }
+
+  @Override
+  public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> handler) {
+    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+    this.consume(result -> {
+      if (result.isSuccess()) {
+        try {
+          final ComposableFuture<? extends R> res = handler.apply(result.getValue());
+          consumeFrom(future, res);
+        } catch (final Throwable e) {
+          future.setException(e);
         }
-    }
+      } else {
+        future.setException(result.getError());
+      }
+    });
 
-    @Override
-    public void setException(final Throwable t) {
-        if (value.compareAndSet(null, Try.fromError(t))) {
-            done();
+    return future;
+  }
+
+  @Override
+  public <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, final Function<E, ? extends T> handler) {
+    final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
+    this.consume(result -> {
+      if (result.isSuccess()) {
+        future.set(result.getValue());
+      } else {
+        try {
+          Throwable error = result.getError();
+          if (errorType.isInstance(error)) {
+            E matchingError = errorType.cast(error);
+            future.set(handler.apply(matchingError));
+          } else {
+            future.setException(error);
+          }
+        } catch (final UncheckedExecutionException e) {
+          future.setException(e.getCause() != null ? e.getCause() : e);
+        } catch (final Throwable e) {
+          future.setException(e);
         }
-    }
+      }
+    });
 
-    @Override
-    public ComposableFuture<T> future() {
-        return this;
-    }
+    return future;
 
-    private void done() {
-        handlers.execute(threadPool);
-    }
+  }
 
-    @Override
-    public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> handler) {
-        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-        this.consume(result -> {
-            if (result.isSuccess()) {
-                try {
-                    future.set(handler.apply(result.getValue()));
-                } catch (final UncheckedExecutionException e) {
-                    future.setException(e.getCause() != null ? e.getCause() : e);
-                } catch (final Throwable e) {
-                    future.setException(e);
-                }
-            } else {
-                future.setException(result.getError());
-            }
-        });
+  @Override
+  public <E extends Throwable> ComposableFuture<T>
+    recoverWith(Class<E> errorType, final Function<E, ? extends ComposableFuture<? extends T>> handler) {
 
-        return future;
-    }
-
-    @Override
-    public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> handler) {
-        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-        this.consume(result -> {
-            if (result.isSuccess()) {
-                try {
-                    final ComposableFuture<? extends R> res = handler.apply(result.getValue());
-                    consumeFrom(future, res);
-                } catch (final Throwable e) {
-                    future.setException(e);
-                }
-            } else {
-                future.setException(result.getError());
-            }
-        });
-
-        return future;
-    }
-
-    @Override
-    public <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, final Function<E, ? extends T> handler) {
-        final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
-        this.consume(result -> {
-            if (result.isSuccess()) {
-                future.set(result.getValue());
-            } else {
-                try {
-                    Throwable error = result.getError();
-                    if (errorType.isInstance(error)) {
-                        E matchingError = errorType.cast(error);
-                        future.set(handler.apply(matchingError));
-                    } else {
-                        future.setException(error);
-                    }
-                } catch (final UncheckedExecutionException e) {
-                    future.setException(e.getCause() != null ? e.getCause() : e);
-                } catch (final Throwable e) {
-                    future.setException(e);
-                }
-            }
-        });
-
-        return future;
-
-    }
-
-    @Override
-    public <E extends Throwable> ComposableFuture<T>
-        recoverWith(Class<E> errorType, final Function<E, ? extends ComposableFuture<? extends T>> handler) {
-
-        final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
-        this.consume(result -> {
-            if (result.isSuccess()) {
-                future.set(result.getValue());
-            } else {
-                try {
-                    Throwable error = result.getError();
-                    if (errorType.isInstance(error)) {
-                        E matchedError = errorType.cast(error);
-                        final ComposableFuture<? extends T> res = handler.apply(matchedError);
-                        consumeFrom(future, res);
-                    } else {
-                        future.setException(error);
-                    }
-                } catch (final Throwable e) {
-                    future.setException(e);
-                }
-            }
-        });
-
-        return future;
-    }
-
-    @Override
-    public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
-        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-        this.consume(res -> {
-            try {
-                future.set(handler.apply(res));
-            } catch (final UncheckedExecutionException e) {
-                future.setException(e.getCause() != null ? e.getCause() : e);
-            } catch (final Throwable e) {
-                future.setException(e);
-            }
-        });
-
-        return future;
-    }
-
-    @Override
-    public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
-        final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
-        this.consume(res -> {
-            try {
-                final ComposableFuture<? extends R> nextResult = handler.apply(res);
-                consumeFrom(future, nextResult);
-            } catch (final Throwable e) {
-                future.setException(e);
-            }
-        });
-
-        return future;
-    }
-
-    @Override
-    public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
-        final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
-        this.consume(result -> {
-            try {
-                resultConsumer.consume(result.map(identity()));
-            } finally {
-                future.setTry(result);
-            }
-        });
-
-        return future;
-    }
-
-    @Override
-    public void consume(final Consumer<? super T> consumer) {
-        handlers.addHandler(new ConsumerAction<>(consumer, this), threadPool);
-    }
-
-    @Override
-    public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit, final String taskDescription) {
-        return withTimeout(ComposableFutures.getScheduler(), duration, unit, taskDescription);
-    }
-
-    @Override
-    public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit, final String taskDescription) {
-        final ComposablePromise<T> deadline = new EagerComposableFuture<>();
-        final CancellationToken cancellationToken = scheduler.schedule(() ->
-                deadline.setException(new TimeoutException("Timeout occurred on task ('" + taskDescription + "' " + timeout + " " + unit + ")")), timeout, unit);
-
-        this.consume(result -> cancellationToken.cancel(false));
-        return collectFirst(asList(this, deadline.future()));
-    }
-
-    @Override
-    public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit) {
-        return withTimeout(ComposableFutures.getScheduler(), duration, unit);
-    }
-
-    @Override
-    public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
-        return withTimeout(scheduler, timeout, unit, "unspecified task");
-    }
-
-    @Override
-    public ComposableFuture<T> materialize() {
-        return this;
-    }
-
-    private <R> void consumeFrom(final ComposablePromise<R> promise, final ComposableFuture<? extends R> future) {
-        if (future == null) {
-            promise.set(null);
-        } else {
-            future.consume(promise::setTry);
+    final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
+    this.consume(result -> {
+      if (result.isSuccess()) {
+        future.set(result.getValue());
+      } else {
+        try {
+          Throwable error = result.getError();
+          if (errorType.isInstance(error)) {
+            E matchedError = errorType.cast(error);
+            final ComposableFuture<? extends T> res = handler.apply(matchedError);
+            consumeFrom(future, res);
+          } else {
+            future.setException(error);
+          }
+        } catch (final Throwable e) {
+          future.setException(e);
         }
+      }
+    });
+
+    return future;
+  }
+
+  @Override
+  public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
+    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+    this.consume(res -> {
+      try {
+        future.set(handler.apply(res));
+      } catch (final UncheckedExecutionException e) {
+        future.setException(e.getCause() != null ? e.getCause() : e);
+      } catch (final Throwable e) {
+        future.setException(e);
+      }
+    });
+
+    return future;
+  }
+
+  @Override
+  public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
+    final EagerComposableFuture<R> future = new EagerComposableFuture<>(threadPool);
+    this.consume(res -> {
+      try {
+        final ComposableFuture<? extends R> nextResult = handler.apply(res);
+        consumeFrom(future, nextResult);
+      } catch (final Throwable e) {
+        future.setException(e);
+      }
+    });
+
+    return future;
+  }
+
+  @Override
+  public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
+    final EagerComposableFuture<T> future = new EagerComposableFuture<>(threadPool);
+    this.consume(result -> {
+      try {
+        resultConsumer.consume(result.map(identity()));
+      } finally {
+        future.setTry(result);
+      }
+    });
+
+    return future;
+  }
+
+  @Override
+  public void consume(final Consumer<? super T> consumer) {
+    handlers.addHandler(new ConsumerAction<>(consumer, this), threadPool);
+  }
+
+  @Override
+  public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit, final String taskDescription) {
+    return withTimeout(ComposableFutures.getScheduler(), duration, unit, taskDescription);
+  }
+
+  @Override
+  public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit, final String taskDescription) {
+    final ComposablePromise<T> deadline = new EagerComposableFuture<>();
+    final CancellationToken cancellationToken = scheduler.schedule(() ->
+        deadline.setException(new TimeoutException("Timeout occurred on task ('" + taskDescription + "' " + timeout + " " + unit + ")")), timeout, unit);
+
+    this.consume(result -> cancellationToken.cancel(false));
+    return collectFirst(asList(this, deadline.future()));
+  }
+
+  @Override
+  public ComposableFuture<T> withTimeout(final long duration, final TimeUnit unit) {
+    return withTimeout(ComposableFutures.getScheduler(), duration, unit);
+  }
+
+  @Override
+  public ComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
+    return withTimeout(scheduler, timeout, unit, "unspecified task");
+  }
+
+  @Override
+  public ComposableFuture<T> materialize() {
+    return this;
+  }
+
+  private <R> void consumeFrom(final ComposablePromise<R> promise, final ComposableFuture<? extends R> future) {
+    if (future == null) {
+      promise.set(null);
+    } else {
+      future.consume(promise::setTry);
     }
+  }
 
   /*
     OLD API - DEPRECATED
  */
 
 
-    @Override
-    @SuppressWarnings({"unchecked", "deprecated"})
-    public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
-        return alwaysWith(handler::handle);
+  @Override
+  @SuppressWarnings({"unchecked", "deprecated"})
+  public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
+    return alwaysWith(handler::handle);
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "deprecated"})
+  public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
+    return always(result -> {
+      try {
+        return handler.handle(result);
+      } catch (final ExecutionException e) {
+        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+        throw new UncheckedExecutionException(e);
+      }
+    });
+  }
+
+  @Override
+  public <R> ComposableFuture<R> continueOnSuccess(final FutureSuccessHandler<? super T, R> handler) {
+    return flatMap(handler::handle); // sweet
+  }
+
+  @Override
+  public <R> ComposableFuture<R> continueOnSuccess(final SuccessHandler<? super T, ? extends R> handler) {
+    return map(result -> {
+      try {
+        return handler.handle(result);
+      } catch (final ExecutionException e) {
+        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+        throw new UncheckedExecutionException(e.getCause());
+      }
+    });
+  }
+
+  @Override
+  public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
+    return recoverWith(handler::handle);
+  }
+
+  @Override
+  public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
+    return recover(error -> {
+      try {
+        return handler.handle(error);
+      } catch (final ExecutionException e) {
+        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+        throw new UncheckedExecutionException(e.getCause());
+      }
+    });
+  }
+
+  @Override
+  public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
+    return map(function::apply);
+  }
+
+  private static class ConsumerAction<T> implements Runnable {
+    final Consumer<? super T> inner;
+    final EagerComposableFuture<T> current;
+
+    private ConsumerAction(final Consumer<? super T> inner, final EagerComposableFuture<T> current) {
+      this.inner = inner;
+      this.current = current;
     }
 
     @Override
-    @SuppressWarnings({"unchecked", "deprecated"})
-    public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
-        return always(result -> {
-            try {
-                return handler.handle(result);
-            } catch (final ExecutionException e) {
-                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-                throw new UncheckedExecutionException(e);
-            }
-        });
+    public void run() {
+      try {
+        final Try<T> currentValue = current.value.get();
+        inner.consume(currentValue.map(identity()));
+      } catch (final Throwable error) {
+        logger.warn("error while handling future callbacks", error);
+      }
     }
-
-    @Override
-    public <R> ComposableFuture<R> continueOnSuccess(final FutureSuccessHandler<? super T, R> handler) {
-        return flatMap(handler::handle); // sweet
-    }
-
-    @Override
-    public <R> ComposableFuture<R> continueOnSuccess(final SuccessHandler<? super T, ? extends R> handler) {
-        return map(result -> {
-            try {
-                return handler.handle(result);
-            } catch (final ExecutionException e) {
-                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-                throw new UncheckedExecutionException(e.getCause());
-            }
-        });
-    }
-
-    @Override
-    public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
-        return recoverWith(handler::handle);
-    }
-
-    @Override
-    public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
-        return recover(error -> {
-            try {
-                return handler.handle(error);
-            } catch (final ExecutionException e) {
-                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-                throw new UncheckedExecutionException(e.getCause());
-            }
-        });
-    }
-
-    @Override
-    public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
-        return map(function::apply);
-    }
-
-    private static class ConsumerAction<T> implements Runnable {
-        final Consumer<? super T> inner;
-        final EagerComposableFuture<T> current;
-
-        private ConsumerAction(final Consumer<? super T> inner, final EagerComposableFuture<T> current) {
-            this.inner = inner;
-            this.current = current;
-        }
-
-        @Override
-        public void run() {
-            try {
-                final Try<T> currentValue = current.value.get();
-                inner.consume(currentValue.map(identity()));
-            } catch (final Throwable error) {
-                logger.warn("error while handling future callbacks", error);
-            }
-        }
-    }
+  }
 }

--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/lazy/LazyComposableFuture.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/lazy/LazyComposableFuture.java
@@ -45,284 +45,298 @@ import static java.util.function.Function.identity;
  */
 public final class LazyComposableFuture<T> implements ComposableFuture<T> {
 
-  private final Producer<T> producer;
-  private final Executor executor;
+    private final Producer<T> producer;
+    private final Executor executor;
 
-  private LazyComposableFuture(final Producer<T> producer) {
-    this(producer, null);
-  }
+    private LazyComposableFuture(final Producer<T> producer) {
+        this(producer, null);
+    }
 
-  private LazyComposableFuture(final Producer<T> producer, final Executor executor) {
-    this.producer = producer;
-    this.executor = executor;
-  }
+    private LazyComposableFuture(final Producer<T> producer, final Executor executor) {
+        this.producer = producer;
+        this.executor = executor;
+    }
 
-  public static <T> LazyComposableFuture<T> fromValue(final T value) {
-    return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromValue(value)));
-  }
+    public static <T> LazyComposableFuture<T> fromValue(final T value) {
+        return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromValue(value)));
+    }
 
-  public static <T> LazyComposableFuture<T> fromError(final Throwable error) {
-    return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromError(error)));
-  }
+    public static <T> LazyComposableFuture<T> fromError(final Throwable error) {
+        return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromError(error)));
+    }
 
-  public static <T> ComposableFuture<T> build(final Producer<T> producer) {
-    return new LazyComposableFuture<>(producer);
-  }
+    public static <T> ComposableFuture<T> build(final Producer<T> producer) {
+        return new LazyComposableFuture<>(producer);
+    }
 
-  public static <T> LazyComposableFuture<T> apply(final Supplier<T> supplier) {
-    return new LazyComposableFuture<>(consumer ->
-      consumer.consume(Try.apply(supplier::get)));
-  }
+    public static <T> LazyComposableFuture<T> apply(final Supplier<T> supplier) {
+        return new LazyComposableFuture<>(consumer ->
+                consumer.consume(Try.apply(supplier::get)));
+    }
 
-  public static <T> LazyComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
-    return new LazyComposableFuture<>(consumer -> executor.execute(() ->
-      consumer.consume(Try.apply(task::call))), delegateHandler ? executor : null);
-  }
+    public static <T> LazyComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
+        return new LazyComposableFuture<>(consumer -> executor.execute(() ->
+                consumer.consume(Try.apply(task::call))), delegateHandler ? executor : null);
+    }
 
-  public static <T> LazyComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit timeUnit) {
-    return new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
-      consumer.consume(Try.apply(task::call)), delay, timeUnit));
-  }
+    public static <T> LazyComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit timeUnit) {
+        return new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
+                consumer.consume(Try.apply(task::call)), delay, timeUnit));
+    }
 
-  public static <T> LazyComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
-    return new LazyComposableFuture<>(consumer -> {
-      final AtomicBoolean done = new AtomicBoolean();
-      for (final ComposableFuture<T> future : futures) {
-        future.consume(result -> {
-          if (done.compareAndSet(false, true)) {
+    public static <T> LazyComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
+        return new LazyComposableFuture<>(consumer -> {
+            final AtomicBoolean done = new AtomicBoolean();
+            for (final ComposableFuture<T> future : futures) {
+                future.consume(result -> {
+                    if (done.compareAndSet(false, true)) {
+                        consumer.consume(result);
+                    }
+                });
+            }
+        });
+    }
+
+    public static <T> LazyComposableFuture<List<T>> collectAll(final List<ComposableFuture<T>> futures) {
+        return new LazyComposableFuture<>(consumer -> {
+            final AtomicInteger counter = new AtomicInteger(futures.size());
+            final AtomicBoolean errorTrigger = new AtomicBoolean(false);
+            final ConcurrentMap<Integer, Try<T>> results = new ConcurrentHashMap<>(futures.size());
+
+            int index = 0;
+            for (final ComposableFuture<T> future : futures) {
+                final int i = index++;
+                future.consume(result -> {
+                    results.put(i, result);
+                    if (result.isSuccess()) {
+                        final int count = counter.decrementAndGet();
+                        if (count == 0) {
+                            consumer.consume(Try.fromValue(createResultList(results)));
+                        }
+                    } else {
+                        if (errorTrigger.compareAndSet(false, true)) {
+                            counter.set(0);
+                            consumer.consume(Try.fromError(result.getError()));
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    private static <T> List<T> createResultList(final ConcurrentMap<Integer, Try<T>> results) {
+        final List<T> list = new ArrayList<>(results.size());
+        for (int i = 0; i < results.size(); i++) {
+            final Try<T> tryValue = results.get(i);
+            list.add(tryValue != null ? tryValue.getValue() : null);
+        }
+
+        return list;
+    }
+
+    @Override
+    public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> mapper) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            if (result.isSuccess()) {
+                try {
+                    consumer.consume(Try.fromValue(mapper.apply(result.getValue())));
+                } catch (final UncheckedExecutionException e) {
+                    final Throwable error = e.getCause() != null ? e.getCause() : e;
+                    consumer.consume(Try.fromError(error));
+                } catch (final Throwable e) {
+                    consumer.consume(Try.fromError(e));
+                }
+            } else {
+                consumer.consume(Try.fromError(result.getError()));
+            }
+        }));
+    }
+
+    @Override
+    public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> mapper) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            if (result.isSuccess()) {
+                try {
+                    final ComposableFuture<? extends R> next = mapper.apply(result.getValue());
+                    if (next == null) {
+                        consumer.consume(Try.fromValue(null));
+                    } else {
+                        next.consume(consumer);
+                    }
+                } catch (final Throwable e) {
+                    consumer.consume(Try.fromError(e));
+                }
+            } else {
+                consumer.consume(Try.fromError(result.getError()));
+            }
+        }));
+    }
+
+    @Override
+    public <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, Function<E, ? extends T> recover) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            if (result.isSuccess()) {
+                consumer.consume(result);
+            } else {
+                try {
+                    Throwable error = result.getError();
+                    if (errorType.isInstance(error)) {
+                        E matchedError = errorType.cast(error);
+                        consumer.consume(Try.fromValue(recover.apply(matchedError)));
+                    } else {
+                        consumer.consume(result);
+                    }
+                } catch (final UncheckedExecutionException e) {
+                    consumer.consume(Try.fromError(e.getCause() != null ? e.getCause() : e));
+                } catch (final Throwable e) {
+                    consumer.consume(Try.fromError(e));
+                }
+            }
+        }));
+    }
+
+    @Override
+    public <E extends Throwable> ComposableFuture<T>
+        recoverWith(Class<E> errorType, final Function<E, ? extends ComposableFuture<? extends T>> recover) {
+
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            if (result.isSuccess()) {
+                consumer.consume(result);
+            } else {
+                try {
+                    Throwable error = result.getError();
+                    if (errorType.isInstance(error)) {
+                        E matchedError = errorType.cast(error);
+                        final ComposableFuture<? extends T> next = recover.apply(matchedError);
+                        if (next == null) {
+                            consumer.consume(Try.fromValue(null));
+                        } else {
+                            next.consume(consumer);
+                        }
+                    } else {
+                        consumer.consume(result);
+                    }
+                } catch (final Throwable e) {
+                    consumer.consume(Try.fromError(e));
+                }
+            }
+        }));
+    }
+
+    @Override
+    public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            try {
+                consumer.consume(Try.fromValue(handler.apply(result)));
+            } catch (final UncheckedExecutionException e) {
+                final Throwable error = e.getCause() != null ? e.getCause() : e;
+                consumer.consume(Try.fromError(error));
+            } catch (final Throwable e) {
+                consumer.consume(Try.fromError(e));
+            }
+        }));
+    }
+
+    @Override
+    public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            try {
+                final ComposableFuture<? extends R> next = handler.apply(result);
+                if (next == null) {
+                    consumer.consume(Try.fromValue(null));
+                } else {
+                    next.consume(consumer);
+                }
+            } catch (final Throwable e) {
+                consumer.consume(Try.fromError(e));
+            }
+        }));
+    }
+
+    @Override
+    public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+            resultConsumer.consume(result.map(identity()));
             consumer.consume(result);
-          }
-        });
-      }
-    });
-  }
-
-  public static <T> LazyComposableFuture<List<T>> collectAll(final List<ComposableFuture<T>> futures) {
-    return new LazyComposableFuture<>(consumer -> {
-      final AtomicInteger counter = new AtomicInteger(futures.size());
-      final AtomicBoolean errorTrigger = new AtomicBoolean(false);
-      final ConcurrentMap<Integer, Try<T>> results = new ConcurrentHashMap<>(futures.size());
-
-      int index = 0;
-      for (final ComposableFuture<T> future : futures) {
-        final int i = index++;
-        future.consume(result -> {
-          results.put(i, result);
-          if (result.isSuccess()) {
-            final int count = counter.decrementAndGet();
-            if (count == 0) {
-              consumer.consume(Try.fromValue(createResultList(results)));
-            }
-          } else {
-            if (errorTrigger.compareAndSet(false, true)) {
-              counter.set(0);
-              consumer.consume(Try.fromError(result.getError()));
-            }
-          }
-        });
-      }
-    });
-  }
-
-  private static <T> List<T> createResultList(final ConcurrentMap<Integer, Try<T>> results) {
-    final List<T> list = new ArrayList<>(results.size());
-    for (int i = 0; i < results.size(); i++) {
-      final Try<T> tryValue = results.get(i);
-      list.add(tryValue != null ? tryValue.getValue() : null);
+        }));
     }
 
-    return list;
-  }
-
-  @Override
-  public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> mapper) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      if (result.isSuccess()) {
-        try {
-          consumer.consume(Try.fromValue(mapper.apply(result.getValue())));
-        } catch (final UncheckedExecutionException e) {
-          final Throwable error = e.getCause() != null ? e.getCause() : e;
-          consumer.consume(Try.fromError(error));
-        } catch (final Throwable e) {
-          consumer.consume(Try.fromError(e));
-        }
-      } else {
-        consumer.consume(Try.fromError(result.getError()));
-      }
-    }));
-  }
-
-  @Override
-  public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> mapper) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      if (result.isSuccess()) {
-        try {
-          final ComposableFuture<? extends R> next = mapper.apply(result.getValue());
-          if (next == null) {
-            consumer.consume(Try.fromValue(null));
-          } else {
-            next.consume(consumer);
-          }
-        } catch (final Throwable e) {
-          consumer.consume(Try.fromError(e));
-        }
-      } else {
-        consumer.consume(Try.fromError(result.getError()));
-      }
-    }));
-  }
-
-  @Override
-  public ComposableFuture<T> recover(final Function<Throwable, ? extends T> recover) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      if (result.isSuccess()) {
-        consumer.consume(result);
-      } else {
-        try {
-          consumer.consume(Try.fromValue(recover.apply(result.getError())));
-        } catch (final UncheckedExecutionException e) {
-          consumer.consume(Try.fromError(e.getCause() != null ? e.getCause() : e));
-        } catch (final Throwable e) {
-          consumer.consume(Try.fromError(e));
-        }
-      }
-    }));
-  }
-
-  @Override
-  public ComposableFuture<T> recoverWith(final Function<Throwable, ? extends ComposableFuture<? extends T>> recover) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      if (result.isSuccess()) {
-        consumer.consume(result);
-      } else {
-        try {
-          final ComposableFuture<? extends T> next = recover.apply(result.getError());
-          if (next == null) {
-            consumer.consume(Try.fromValue(null));
-          } else {
-            next.consume(consumer);
-          }
-        } catch (final Throwable e) {
-          consumer.consume(Try.fromError(e));
-        }
-      }
-    }));
-  }
-
-  @Override
-  public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      try {
-        consumer.consume(Try.fromValue(handler.apply(result)));
-      } catch (final UncheckedExecutionException e) {
-        final Throwable error = e.getCause() != null ? e.getCause() : e;
-        consumer.consume(Try.fromError(error));
-      } catch (final Throwable e) {
-        consumer.consume(Try.fromError(e));
-      }
-    }));
-  }
-
-  @Override
-  public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      try {
-        final ComposableFuture<? extends R> next = handler.apply(result);
-        if (next == null) {
-          consumer.consume(Try.fromValue(null));
+    @Override
+    public void consume(final Consumer<? super T> consumer) {
+        if (executor != null) {
+            executor.execute(() -> consumeValue(consumer));
         } else {
-          next.consume(consumer);
+            consumeValue(consumer);
         }
-      } catch (final Throwable e) {
-        consumer.consume(Try.fromError(e));
-      }
-    }));
-  }
-
-  @Override
-  public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-      resultConsumer.consume(result.map(identity()));
-      consumer.consume(result);
-    }));
-  }
-
-  @Override
-  public void consume(final Consumer<? super T> consumer) {
-    if (executor != null) {
-      executor.execute(() -> consumeValue(consumer));
-    } else {
-      consumeValue(consumer);
     }
-  }
 
-  private void consumeValue(final Consumer<? super T> consumer) {
-    producer.produce(valueTry -> consumer.consume(valueTry.map(identity())));
-  }
+    private void consumeValue(final Consumer<? super T> consumer) {
+        producer.produce(valueTry -> consumer.consume(valueTry.map(identity())));
+    }
 
-  @Override
-  public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit,
-                                             final String taskDescription) {
-    final LazyComposableFuture<T> deadline = new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
-      consumer.consume(Try.fromError(
-        new TimeoutException("Timeout occurred on task ('" +
-                             taskDescription + "' " +
-                             timeout + " " +
-                             unit + ")"))),
-          timeout, unit));
+    @Override
+    public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit,
+                                               final String taskDescription) {
+        final LazyComposableFuture<T> deadline = new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
+                        consumer.consume(Try.fromError(
+                                new TimeoutException("Timeout occurred on task ('" +
+                                        taskDescription + "' " +
+                                        timeout + " " +
+                                        unit + ")"))),
+                timeout, unit));
 
-    return collectFirst(Arrays.asList(this, deadline));
-  }
+        return collectFirst(Arrays.asList(this, deadline));
+    }
 
-  @Override
-  public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
-    return withTimeout(scheduler, timeout, unit, "unspecified context");
-  }
+    @Override
+    public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
+        return withTimeout(scheduler, timeout, unit, "unspecified context");
+    }
 
-  @Override
-  public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit, final String taskDescription) {
-    return withTimeout(ComposableFutures.getScheduler(), timeout, unit, taskDescription);
-  }
+    @Override
+    public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit, final String taskDescription) {
+        return withTimeout(ComposableFutures.getScheduler(), timeout, unit, taskDescription);
+    }
 
-  @Override
-  public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit) {
-    return withTimeout(ComposableFutures.getScheduler(), timeout, unit);
-  }
+    @Override
+    public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit) {
+        return withTimeout(ComposableFutures.getScheduler(), timeout, unit);
+    }
 
-  @Override
-  public ComposableFuture<T> materialize() {
-    return ComposableFutures.buildEager(producer);
-  }
+    @Override
+    public ComposableFuture<T> materialize() {
+        return ComposableFutures.buildEager(producer);
+    }
 
-  public LazyComposableFuture<T> doubleDispatch(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
-    final LazyComposableFuture<T> outer = this;
-    return new LazyComposableFuture<>(consumer -> {
-      final AtomicBoolean done = new AtomicBoolean();
+    public LazyComposableFuture<T> doubleDispatch(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
+        final LazyComposableFuture<T> outer = this;
+        return new LazyComposableFuture<>(consumer -> {
+            final AtomicBoolean done = new AtomicBoolean();
 
-      outer.consume(firstRes -> {
-        if (done.compareAndSet(false, true)) {
-          consumer.consume(firstRes);
-        }
-      });
+            outer.consume(firstRes -> {
+                if (done.compareAndSet(false, true)) {
+                    consumer.consume(firstRes);
+                }
+            });
 
-      scheduler.schedule(() -> {
-        if (!done.get()) {
-          outer.consume(secondRes -> {
-            if (done.compareAndSet(false, true)) {
-              consumer.consume(secondRes);
-            }
-          });
-        }
-      }, timeout, unit);
-    });
-  }
+            scheduler.schedule(() -> {
+                if (!done.get()) {
+                    outer.consume(secondRes -> {
+                        if (done.compareAndSet(false, true)) {
+                            consumer.consume(secondRes);
+                        }
+                    });
+                }
+            }, timeout, unit);
+        });
+    }
 
 
   /*
@@ -330,63 +344,63 @@ public final class LazyComposableFuture<T> implements ComposableFuture<T> {
  */
 
 
-  @Override
-  @SuppressWarnings({"unchecked", "deprecated"})
-  public <U> ComposableFuture<U> continueOnSuccess(final SuccessHandler<? super T, ? extends U> handler) {
-    return map(result -> {
-      try {
-        return handler.handle(result);
-      } catch (final ExecutionException e) {
-        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-        throw new UncheckedExecutionException(e.getCause());
-      }
-    });
-  }
+    @Override
+    @SuppressWarnings({"unchecked", "deprecated"})
+    public <U> ComposableFuture<U> continueOnSuccess(final SuccessHandler<? super T, ? extends U> handler) {
+        return map(result -> {
+            try {
+                return handler.handle(result);
+            } catch (final ExecutionException e) {
+                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+                throw new UncheckedExecutionException(e.getCause());
+            }
+        });
+    }
 
-  @Override
-  @SuppressWarnings({"unchecked", "deprecated"})
-  public <U> ComposableFuture<U> continueOnSuccess(final FutureSuccessHandler<? super T, U> handler) {
-    return flatMap(handler::handle);
-  }
+    @Override
+    @SuppressWarnings({"unchecked", "deprecated"})
+    public <U> ComposableFuture<U> continueOnSuccess(final FutureSuccessHandler<? super T, U> handler) {
+        return flatMap(handler::handle);
+    }
 
-  @Override
-  @SuppressWarnings({"unchecked", "deprecated"})
-  public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
-    return recover(error -> {
-      try {
-        return handler.handle(error);
-      } catch (final ExecutionException e) {
-        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-        throw new UncheckedExecutionException(e.getCause());
-      }
-    });
-  }
+    @Override
+    @SuppressWarnings({"unchecked", "deprecated"})
+    public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
+        return recover(error -> {
+            try {
+                return handler.handle(error);
+            } catch (final ExecutionException e) {
+                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+                throw new UncheckedExecutionException(e.getCause());
+            }
+        });
+    }
 
-  @Override
-  public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
-    return recoverWith(handler::handle);
-  }
+    @Override
+    public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
+        return recoverWith(handler::handle);
+    }
 
-  @Override
-  public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
-    return always(result -> {
-      try {
-        return handler.handle(result);
-      } catch (final ExecutionException e) {
-        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-        throw new UncheckedExecutionException(e);
-      }
-    });
-  }
+    @Override
+    public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
+        return always(result -> {
+            try {
+                return handler.handle(result);
+            } catch (final ExecutionException e) {
+                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+                throw new UncheckedExecutionException(e);
+            }
+        });
+    }
 
-  @Override
-  @SuppressWarnings({"unchecked", "deprecated"})
-  public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
-    return alwaysWith(handler::handle);
-  }
+    @Override
+    @SuppressWarnings({"unchecked", "deprecated"})
+    public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
+        return alwaysWith(handler::handle);
+    }
 
-  @Override
-  public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
-    return map(function::apply);
-  }
+    @Override
+    public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
+        return map(function::apply);
+    }
 }

--- a/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/lazy/LazyComposableFuture.java
+++ b/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/lazy/LazyComposableFuture.java
@@ -45,298 +45,298 @@ import static java.util.function.Function.identity;
  */
 public final class LazyComposableFuture<T> implements ComposableFuture<T> {
 
-    private final Producer<T> producer;
-    private final Executor executor;
+  private final Producer<T> producer;
+  private final Executor executor;
 
-    private LazyComposableFuture(final Producer<T> producer) {
-        this(producer, null);
-    }
+  private LazyComposableFuture(final Producer<T> producer) {
+    this(producer, null);
+  }
 
-    private LazyComposableFuture(final Producer<T> producer, final Executor executor) {
-        this.producer = producer;
-        this.executor = executor;
-    }
+  private LazyComposableFuture(final Producer<T> producer, final Executor executor) {
+    this.producer = producer;
+    this.executor = executor;
+  }
 
-    public static <T> LazyComposableFuture<T> fromValue(final T value) {
-        return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromValue(value)));
-    }
+  public static <T> LazyComposableFuture<T> fromValue(final T value) {
+    return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromValue(value)));
+  }
 
-    public static <T> LazyComposableFuture<T> fromError(final Throwable error) {
-        return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromError(error)));
-    }
+  public static <T> LazyComposableFuture<T> fromError(final Throwable error) {
+    return new LazyComposableFuture<>(consumer -> consumer.consume(Try.fromError(error)));
+  }
 
-    public static <T> ComposableFuture<T> build(final Producer<T> producer) {
-        return new LazyComposableFuture<>(producer);
-    }
+  public static <T> ComposableFuture<T> build(final Producer<T> producer) {
+    return new LazyComposableFuture<>(producer);
+  }
 
-    public static <T> LazyComposableFuture<T> apply(final Supplier<T> supplier) {
-        return new LazyComposableFuture<>(consumer ->
-                consumer.consume(Try.apply(supplier::get)));
-    }
+  public static <T> LazyComposableFuture<T> apply(final Supplier<T> supplier) {
+    return new LazyComposableFuture<>(consumer ->
+        consumer.consume(Try.apply(supplier::get)));
+  }
 
-    public static <T> LazyComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
-        return new LazyComposableFuture<>(consumer -> executor.execute(() ->
-                consumer.consume(Try.apply(task::call))), delegateHandler ? executor : null);
-    }
+  public static <T> LazyComposableFuture<T> submit(final Executor executor, final Callable<T> task, final boolean delegateHandler) {
+    return new LazyComposableFuture<>(consumer -> executor.execute(() ->
+        consumer.consume(Try.apply(task::call))), delegateHandler ? executor : null);
+  }
 
-    public static <T> LazyComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit timeUnit) {
-        return new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
-                consumer.consume(Try.apply(task::call)), delay, timeUnit));
-    }
+  public static <T> LazyComposableFuture<T> schedule(final Scheduler scheduler, final Callable<T> task, final long delay, final TimeUnit timeUnit) {
+    return new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
+        consumer.consume(Try.apply(task::call)), delay, timeUnit));
+  }
 
-    public static <T> LazyComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
-        return new LazyComposableFuture<>(consumer -> {
-            final AtomicBoolean done = new AtomicBoolean();
-            for (final ComposableFuture<T> future : futures) {
-                future.consume(result -> {
-                    if (done.compareAndSet(false, true)) {
-                        consumer.consume(result);
-                    }
-                });
-            }
-        });
-    }
-
-    public static <T> LazyComposableFuture<List<T>> collectAll(final List<ComposableFuture<T>> futures) {
-        return new LazyComposableFuture<>(consumer -> {
-            final AtomicInteger counter = new AtomicInteger(futures.size());
-            final AtomicBoolean errorTrigger = new AtomicBoolean(false);
-            final ConcurrentMap<Integer, Try<T>> results = new ConcurrentHashMap<>(futures.size());
-
-            int index = 0;
-            for (final ComposableFuture<T> future : futures) {
-                final int i = index++;
-                future.consume(result -> {
-                    results.put(i, result);
-                    if (result.isSuccess()) {
-                        final int count = counter.decrementAndGet();
-                        if (count == 0) {
-                            consumer.consume(Try.fromValue(createResultList(results)));
-                        }
-                    } else {
-                        if (errorTrigger.compareAndSet(false, true)) {
-                            counter.set(0);
-                            consumer.consume(Try.fromError(result.getError()));
-                        }
-                    }
-                });
-            }
-        });
-    }
-
-    private static <T> List<T> createResultList(final ConcurrentMap<Integer, Try<T>> results) {
-        final List<T> list = new ArrayList<>(results.size());
-        for (int i = 0; i < results.size(); i++) {
-            final Try<T> tryValue = results.get(i);
-            list.add(tryValue != null ? tryValue.getValue() : null);
-        }
-
-        return list;
-    }
-
-    @Override
-    public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> mapper) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            if (result.isSuccess()) {
-                try {
-                    consumer.consume(Try.fromValue(mapper.apply(result.getValue())));
-                } catch (final UncheckedExecutionException e) {
-                    final Throwable error = e.getCause() != null ? e.getCause() : e;
-                    consumer.consume(Try.fromError(error));
-                } catch (final Throwable e) {
-                    consumer.consume(Try.fromError(e));
-                }
-            } else {
-                consumer.consume(Try.fromError(result.getError()));
-            }
-        }));
-    }
-
-    @Override
-    public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> mapper) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            if (result.isSuccess()) {
-                try {
-                    final ComposableFuture<? extends R> next = mapper.apply(result.getValue());
-                    if (next == null) {
-                        consumer.consume(Try.fromValue(null));
-                    } else {
-                        next.consume(consumer);
-                    }
-                } catch (final Throwable e) {
-                    consumer.consume(Try.fromError(e));
-                }
-            } else {
-                consumer.consume(Try.fromError(result.getError()));
-            }
-        }));
-    }
-
-    @Override
-    public <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, Function<E, ? extends T> recover) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            if (result.isSuccess()) {
-                consumer.consume(result);
-            } else {
-                try {
-                    Throwable error = result.getError();
-                    if (errorType.isInstance(error)) {
-                        E matchedError = errorType.cast(error);
-                        consumer.consume(Try.fromValue(recover.apply(matchedError)));
-                    } else {
-                        consumer.consume(result);
-                    }
-                } catch (final UncheckedExecutionException e) {
-                    consumer.consume(Try.fromError(e.getCause() != null ? e.getCause() : e));
-                } catch (final Throwable e) {
-                    consumer.consume(Try.fromError(e));
-                }
-            }
-        }));
-    }
-
-    @Override
-    public <E extends Throwable> ComposableFuture<T>
-        recoverWith(Class<E> errorType, final Function<E, ? extends ComposableFuture<? extends T>> recover) {
-
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            if (result.isSuccess()) {
-                consumer.consume(result);
-            } else {
-                try {
-                    Throwable error = result.getError();
-                    if (errorType.isInstance(error)) {
-                        E matchedError = errorType.cast(error);
-                        final ComposableFuture<? extends T> next = recover.apply(matchedError);
-                        if (next == null) {
-                            consumer.consume(Try.fromValue(null));
-                        } else {
-                            next.consume(consumer);
-                        }
-                    } else {
-                        consumer.consume(result);
-                    }
-                } catch (final Throwable e) {
-                    consumer.consume(Try.fromError(e));
-                }
-            }
-        }));
-    }
-
-    @Override
-    public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            try {
-                consumer.consume(Try.fromValue(handler.apply(result)));
-            } catch (final UncheckedExecutionException e) {
-                final Throwable error = e.getCause() != null ? e.getCause() : e;
-                consumer.consume(Try.fromError(error));
-            } catch (final Throwable e) {
-                consumer.consume(Try.fromError(e));
-            }
-        }));
-    }
-
-    @Override
-    public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            try {
-                final ComposableFuture<? extends R> next = handler.apply(result);
-                if (next == null) {
-                    consumer.consume(Try.fromValue(null));
-                } else {
-                    next.consume(consumer);
-                }
-            } catch (final Throwable e) {
-                consumer.consume(Try.fromError(e));
-            }
-        }));
-    }
-
-    @Override
-    public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
-            resultConsumer.consume(result.map(identity()));
+  public static <T> LazyComposableFuture<T> collectFirst(final List<ComposableFuture<T>> futures) {
+    return new LazyComposableFuture<>(consumer -> {
+      final AtomicBoolean done = new AtomicBoolean();
+      for (final ComposableFuture<T> future : futures) {
+        future.consume(result -> {
+          if (done.compareAndSet(false, true)) {
             consumer.consume(result);
-        }));
-    }
-
-    @Override
-    public void consume(final Consumer<? super T> consumer) {
-        if (executor != null) {
-            executor.execute(() -> consumeValue(consumer));
-        } else {
-            consumeValue(consumer);
-        }
-    }
-
-    private void consumeValue(final Consumer<? super T> consumer) {
-        producer.produce(valueTry -> consumer.consume(valueTry.map(identity())));
-    }
-
-    @Override
-    public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit,
-                                               final String taskDescription) {
-        final LazyComposableFuture<T> deadline = new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
-                        consumer.consume(Try.fromError(
-                                new TimeoutException("Timeout occurred on task ('" +
-                                        taskDescription + "' " +
-                                        timeout + " " +
-                                        unit + ")"))),
-                timeout, unit));
-
-        return collectFirst(Arrays.asList(this, deadline));
-    }
-
-    @Override
-    public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
-        return withTimeout(scheduler, timeout, unit, "unspecified context");
-    }
-
-    @Override
-    public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit, final String taskDescription) {
-        return withTimeout(ComposableFutures.getScheduler(), timeout, unit, taskDescription);
-    }
-
-    @Override
-    public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit) {
-        return withTimeout(ComposableFutures.getScheduler(), timeout, unit);
-    }
-
-    @Override
-    public ComposableFuture<T> materialize() {
-        return ComposableFutures.buildEager(producer);
-    }
-
-    public LazyComposableFuture<T> doubleDispatch(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
-        final LazyComposableFuture<T> outer = this;
-        return new LazyComposableFuture<>(consumer -> {
-            final AtomicBoolean done = new AtomicBoolean();
-
-            outer.consume(firstRes -> {
-                if (done.compareAndSet(false, true)) {
-                    consumer.consume(firstRes);
-                }
-            });
-
-            scheduler.schedule(() -> {
-                if (!done.get()) {
-                    outer.consume(secondRes -> {
-                        if (done.compareAndSet(false, true)) {
-                            consumer.consume(secondRes);
-                        }
-                    });
-                }
-            }, timeout, unit);
+          }
         });
+      }
+    });
+  }
+
+  public static <T> LazyComposableFuture<List<T>> collectAll(final List<ComposableFuture<T>> futures) {
+    return new LazyComposableFuture<>(consumer -> {
+      final AtomicInteger counter = new AtomicInteger(futures.size());
+      final AtomicBoolean errorTrigger = new AtomicBoolean(false);
+      final ConcurrentMap<Integer, Try<T>> results = new ConcurrentHashMap<>(futures.size());
+
+      int index = 0;
+      for (final ComposableFuture<T> future : futures) {
+        final int i = index++;
+        future.consume(result -> {
+          results.put(i, result);
+          if (result.isSuccess()) {
+            final int count = counter.decrementAndGet();
+            if (count == 0) {
+              consumer.consume(Try.fromValue(createResultList(results)));
+            }
+          } else {
+            if (errorTrigger.compareAndSet(false, true)) {
+              counter.set(0);
+              consumer.consume(Try.fromError(result.getError()));
+            }
+          }
+        });
+      }
+    });
+  }
+
+  private static <T> List<T> createResultList(final ConcurrentMap<Integer, Try<T>> results) {
+    final List<T> list = new ArrayList<>(results.size());
+    for (int i = 0; i < results.size(); i++) {
+      final Try<T> tryValue = results.get(i);
+      list.add(tryValue != null ? tryValue.getValue() : null);
     }
+
+    return list;
+  }
+
+  @Override
+  public <R> ComposableFuture<R> map(final Function<? super T, ? extends R> mapper) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      if (result.isSuccess()) {
+        try {
+          consumer.consume(Try.fromValue(mapper.apply(result.getValue())));
+        } catch (final UncheckedExecutionException e) {
+          final Throwable error = e.getCause() != null ? e.getCause() : e;
+          consumer.consume(Try.fromError(error));
+        } catch (final Throwable e) {
+          consumer.consume(Try.fromError(e));
+        }
+      } else {
+        consumer.consume(Try.fromError(result.getError()));
+      }
+    }));
+  }
+
+  @Override
+  public <R> ComposableFuture<R> flatMap(final Function<? super T, ? extends ComposableFuture<? extends R>> mapper) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      if (result.isSuccess()) {
+        try {
+          final ComposableFuture<? extends R> next = mapper.apply(result.getValue());
+          if (next == null) {
+            consumer.consume(Try.fromValue(null));
+          } else {
+            next.consume(consumer);
+          }
+        } catch (final Throwable e) {
+          consumer.consume(Try.fromError(e));
+        }
+      } else {
+        consumer.consume(Try.fromError(result.getError()));
+      }
+    }));
+  }
+
+  @Override
+  public <E extends Throwable> ComposableFuture<T> recover(Class<E> errorType, Function<E, ? extends T> recover) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      if (result.isSuccess()) {
+        consumer.consume(result);
+      } else {
+        try {
+          Throwable error = result.getError();
+          if (errorType.isInstance(error)) {
+            E matchedError = errorType.cast(error);
+            consumer.consume(Try.fromValue(recover.apply(matchedError)));
+          } else {
+            consumer.consume(result);
+          }
+        } catch (final UncheckedExecutionException e) {
+          consumer.consume(Try.fromError(e.getCause() != null ? e.getCause() : e));
+        } catch (final Throwable e) {
+          consumer.consume(Try.fromError(e));
+        }
+      }
+    }));
+  }
+
+  @Override
+  public <E extends Throwable> ComposableFuture<T>
+    recoverWith(Class<E> errorType, final Function<E, ? extends ComposableFuture<? extends T>> recover) {
+
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      if (result.isSuccess()) {
+        consumer.consume(result);
+      } else {
+        try {
+          Throwable error = result.getError();
+          if (errorType.isInstance(error)) {
+            E matchedError = errorType.cast(error);
+            final ComposableFuture<? extends T> next = recover.apply(matchedError);
+            if (next == null) {
+              consumer.consume(Try.fromValue(null));
+            } else {
+              next.consume(consumer);
+            }
+          } else {
+            consumer.consume(result);
+          }
+        } catch (final Throwable e) {
+          consumer.consume(Try.fromError(e));
+        }
+      }
+    }));
+  }
+
+  @Override
+  public <R> ComposableFuture<R> always(final Function<Try<T>, ? extends R> handler) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      try {
+        consumer.consume(Try.fromValue(handler.apply(result)));
+      } catch (final UncheckedExecutionException e) {
+        final Throwable error = e.getCause() != null ? e.getCause() : e;
+        consumer.consume(Try.fromError(error));
+      } catch (final Throwable e) {
+        consumer.consume(Try.fromError(e));
+      }
+    }));
+  }
+
+  @Override
+  public <R> ComposableFuture<R> alwaysWith(final Function<Try<T>, ? extends ComposableFuture<? extends R>> handler) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      try {
+        final ComposableFuture<? extends R> next = handler.apply(result);
+        if (next == null) {
+          consumer.consume(Try.fromValue(null));
+        } else {
+          next.consume(consumer);
+        }
+      } catch (final Throwable e) {
+        consumer.consume(Try.fromError(e));
+      }
+    }));
+  }
+
+  @Override
+  public ComposableFuture<T> andThen(final Consumer<? super T> resultConsumer) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> outer.consume(result -> {
+      resultConsumer.consume(result.map(identity()));
+      consumer.consume(result);
+    }));
+  }
+
+  @Override
+  public void consume(final Consumer<? super T> consumer) {
+    if (executor != null) {
+      executor.execute(() -> consumeValue(consumer));
+    } else {
+      consumeValue(consumer);
+    }
+  }
+
+  private void consumeValue(final Consumer<? super T> consumer) {
+    producer.produce(valueTry -> consumer.consume(valueTry.map(identity())));
+  }
+
+  @Override
+  public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit,
+                                             final String taskDescription) {
+    final LazyComposableFuture<T> deadline = new LazyComposableFuture<>(consumer -> scheduler.schedule(() ->
+            consumer.consume(Try.fromError(
+                new TimeoutException("Timeout occurred on task ('" +
+                    taskDescription + "' " +
+                    timeout + " " +
+                    unit + ")"))),
+        timeout, unit));
+
+    return collectFirst(Arrays.asList(this, deadline));
+  }
+
+  @Override
+  public LazyComposableFuture<T> withTimeout(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
+    return withTimeout(scheduler, timeout, unit, "unspecified context");
+  }
+
+  @Override
+  public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit, final String taskDescription) {
+    return withTimeout(ComposableFutures.getScheduler(), timeout, unit, taskDescription);
+  }
+
+  @Override
+  public LazyComposableFuture<T> withTimeout(final long timeout, final TimeUnit unit) {
+    return withTimeout(ComposableFutures.getScheduler(), timeout, unit);
+  }
+
+  @Override
+  public ComposableFuture<T> materialize() {
+    return ComposableFutures.buildEager(producer);
+  }
+
+  public LazyComposableFuture<T> doubleDispatch(final Scheduler scheduler, final long timeout, final TimeUnit unit) {
+    final LazyComposableFuture<T> outer = this;
+    return new LazyComposableFuture<>(consumer -> {
+      final AtomicBoolean done = new AtomicBoolean();
+
+      outer.consume(firstRes -> {
+        if (done.compareAndSet(false, true)) {
+          consumer.consume(firstRes);
+        }
+      });
+
+      scheduler.schedule(() -> {
+        if (!done.get()) {
+          outer.consume(secondRes -> {
+            if (done.compareAndSet(false, true)) {
+              consumer.consume(secondRes);
+            }
+          });
+        }
+      }, timeout, unit);
+    });
+  }
 
 
   /*
@@ -344,63 +344,63 @@ public final class LazyComposableFuture<T> implements ComposableFuture<T> {
  */
 
 
-    @Override
-    @SuppressWarnings({"unchecked", "deprecated"})
-    public <U> ComposableFuture<U> continueOnSuccess(final SuccessHandler<? super T, ? extends U> handler) {
-        return map(result -> {
-            try {
-                return handler.handle(result);
-            } catch (final ExecutionException e) {
-                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-                throw new UncheckedExecutionException(e.getCause());
-            }
-        });
-    }
+  @Override
+  @SuppressWarnings({"unchecked", "deprecated"})
+  public <U> ComposableFuture<U> continueOnSuccess(final SuccessHandler<? super T, ? extends U> handler) {
+    return map(result -> {
+      try {
+        return handler.handle(result);
+      } catch (final ExecutionException e) {
+        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+        throw new UncheckedExecutionException(e.getCause());
+      }
+    });
+  }
 
-    @Override
-    @SuppressWarnings({"unchecked", "deprecated"})
-    public <U> ComposableFuture<U> continueOnSuccess(final FutureSuccessHandler<? super T, U> handler) {
-        return flatMap(handler::handle);
-    }
+  @Override
+  @SuppressWarnings({"unchecked", "deprecated"})
+  public <U> ComposableFuture<U> continueOnSuccess(final FutureSuccessHandler<? super T, U> handler) {
+    return flatMap(handler::handle);
+  }
 
-    @Override
-    @SuppressWarnings({"unchecked", "deprecated"})
-    public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
-        return recover(error -> {
-            try {
-                return handler.handle(error);
-            } catch (final ExecutionException e) {
-                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-                throw new UncheckedExecutionException(e.getCause());
-            }
-        });
-    }
+  @Override
+  @SuppressWarnings({"unchecked", "deprecated"})
+  public ComposableFuture<T> continueOnError(final ErrorHandler<? extends T> handler) {
+    return recover(error -> {
+      try {
+        return handler.handle(error);
+      } catch (final ExecutionException e) {
+        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+        throw new UncheckedExecutionException(e.getCause());
+      }
+    });
+  }
 
-    @Override
-    public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
-        return recoverWith(handler::handle);
-    }
+  @Override
+  public ComposableFuture<T> continueOnError(final FutureErrorHandler<T> handler) {
+    return recoverWith(handler::handle);
+  }
 
-    @Override
-    public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
-        return always(result -> {
-            try {
-                return handler.handle(result);
-            } catch (final ExecutionException e) {
-                // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
-                throw new UncheckedExecutionException(e);
-            }
-        });
-    }
+  @Override
+  public <R> ComposableFuture<R> continueWith(final ResultHandler<T, R> handler) {
+    return always(result -> {
+      try {
+        return handler.handle(result);
+      } catch (final ExecutionException e) {
+        // new API doesn't allows checked exceptions - offering throwing runtime instead. sadly, doing this for BC.
+        throw new UncheckedExecutionException(e);
+      }
+    });
+  }
 
-    @Override
-    @SuppressWarnings({"unchecked", "deprecated"})
-    public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
-        return alwaysWith(handler::handle);
-    }
+  @Override
+  @SuppressWarnings({"unchecked", "deprecated"})
+  public <R> ComposableFuture<R> continueWith(final FutureResultHandler<T, R> handler) {
+    return alwaysWith(handler::handle);
+  }
 
-    @Override
-    public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
-        return map(function::apply);
-    }
+  @Override
+  public <R> ComposableFuture<R> transform(final com.google.common.base.Function<? super T, ? extends R> function) {
+    return map(function::apply);
+  }
 }

--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
@@ -31,551 +31,551 @@ import static org.junit.Assert.*;
  */
 public class ComposableFutureTest {
 
-    private static final int ITERATIONS = 100000;
+  private static final int ITERATIONS = 100000;
 
-    private static long computeHash(final long seed) {
-        long value = seed;
-        for (int i = 0; i < 10000; i++) {
-            value ^= value << 13;
-            value ^= value >>> 17;
-            value ^= value << 5;
-        }
-
-        return value;
+  private static long computeHash(final long seed) {
+    long value = seed;
+    for (int i = 0; i < 10000; i++) {
+      value ^= value << 13;
+      value ^= value >>> 17;
+      value ^= value << 5;
     }
 
-    @Test
-    public void testForeach() throws ExecutionException, InterruptedException {
-        final List<Integer> numbers = new ArrayList<>();
-        for (int i = 1; i <= 10; i++) {
-            numbers.add(i);
-        }
+    return value;
+  }
 
-        final List<Integer> empty = new ArrayList<>();
-        final ComposableFuture<List<Integer>> first3Even = foreach(numbers, empty, (element, aggregateResult) -> {
-            if (aggregateResult.size() < 3 && element % 2 == 0) {
-                aggregateResult.add(element);
-            }
-
-            return fromValue(aggregateResult);
-        });
-
-        final List<Integer> result = first3Even.get();
-        assertEquals(result.size(), 3);
-        assertEquals(result.get(0), new Integer(2));
-        assertEquals(result.get(1), new Integer(4));
-        assertEquals(result.get(2), new Integer(6));
+  @Test
+  public void testForeach() throws ExecutionException, InterruptedException {
+    final List<Integer> numbers = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      numbers.add(i);
     }
 
-    @Test
-    public void testRepeat() throws Exception {
-        final ComposableFuture<Integer> future = repeat(10, 0, result -> fromValue(result + 1));
-        assertEquals(10, (int) future.get());
+    final List<Integer> empty = new ArrayList<>();
+    final ComposableFuture<List<Integer>> first3Even = foreach(numbers, empty, (element, aggregateResult) -> {
+      if (aggregateResult.size() < 3 && element % 2 == 0) {
+        aggregateResult.add(element);
+      }
+
+      return fromValue(aggregateResult);
+    });
+
+    final List<Integer> result = first3Even.get();
+    assertEquals(result.size(), 3);
+    assertEquals(result.get(0), new Integer(2));
+    assertEquals(result.get(1), new Integer(4));
+    assertEquals(result.get(2), new Integer(6));
+  }
+
+  @Test
+  public void testRepeat() throws Exception {
+    final ComposableFuture<Integer> future = repeat(10, 0, result -> fromValue(result + 1));
+    assertEquals(10, (int) future.get());
+  }
+
+  @Test
+  public void testEnsure() throws Exception {
+    final ComposableFuture<String> future = fromValue("hello").ensure(String::isEmpty);
+    try {
+      future.get();
+    } catch (final ExecutionException e) {
+      assertEquals("ensure failed the chain with NoSuchElementException",
+          NoSuchElementException.class, e.getCause().getClass());
+      return;
     }
 
-    @Test
-    public void testEnsure() throws Exception {
-        final ComposableFuture<String> future = fromValue("hello").ensure(String::isEmpty);
-        try {
-            future.get();
-        } catch (final ExecutionException e) {
-            assertEquals("ensure failed the chain with NoSuchElementException",
-                    NoSuchElementException.class, e.getCause().getClass());
-            return;
-        }
+    fail("exception should have been thrown");
+  }
 
-        fail("exception should have been thrown");
+  @Test
+  public void testAndThen() throws Exception {
+    final List<String> results = new ArrayList<>(1);
+    final ComposableFuture<String> future = fromValue("hello").
+        andThen(valueTry -> results.add(valueTry.getValue()));
+
+    final String value = future.get();
+
+    assertEquals("future value should be still 'hello'", "hello", value);
+    assertEquals("list should contain one result", 1, results.size());
+  }
+
+  @Test
+  public void testSuccessful() throws Exception {
+    final ComposableFuture<String> failureFuture = fromError(new RuntimeException("failureFuture"));
+    final ComposableFuture<Try<String>> successfulFuture = failureFuture.successful();
+
+    final Try<String> failureTry = successfulFuture.get();
+    assertTrue("Try is Failure", failureTry.isFailure());
+    assertEquals("Failure type is RuntimeException", RuntimeException.class, failureTry.getError().getClass());
+  }
+
+  @Test
+  public void testDelayedFuture() throws Exception {
+    final ComposableFuture<Long> successFuture = fromValue(currentTimeMillis());
+    final long timeTook = successFuture.delay(1000, MILLISECONDS).map(time -> currentTimeMillis() - time).get();
+
+    assertTrue("thread should have been waiting for at least 500ms (1s delay)", timeTook > 500);
+  }
+
+  @Test
+  public void testRecursive() throws Exception {
+    final AtomicInteger atomicInteger = new AtomicInteger();
+    final ComposableFuture<Integer> future = recursive(() -> fromValue(atomicInteger.incrementAndGet()), input -> input >= 10);
+    assertEquals(10, (int) future.get());
+  }
+
+  @Test
+  public void testBatch() throws Exception {
+    final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    final ComposableFuture<List<String>> res = batch(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
+
+    final List<String> results = res.get();
+    assertEquals(results.size(), nums.size());
+
+  }
+
+  @Test
+  public void testBatchUnordered() throws Exception {
+    final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    final ComposableFuture<List<String>> res = batchUnordered(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
+
+    final List<String> results = res.get();
+    assertEquals(results.size(), nums.size());
+
+  }
+
+  @Test
+  public void testBatchToStream() throws Exception {
+    final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    final Observable<List<String>> stream = batchToStream(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
+
+    final Iterable<List<String>> iterator = stream.toBlocking().toIterable();
+    int totalElements = 0;
+    for (final List<String> batch : iterator) {
+      final int batchSize = batch.size();
+      totalElements += batchSize;
+      assertEquals(batchSize, 2);
+    }
+    assertEquals(totalElements, nums.size());
+  }
+
+  @Test
+  @Ignore("performance test")
+  public void testThreadPool() {
+    testWithRegularThreadPool(true);
+    //    testWithRegularThreadPool(false);
+  }
+
+  @Test
+  @Ignore("performance test")
+  public void testSingleThreadBenchmark() {
+    final long t1 = currentTimeMillis();
+    long sum = 0;
+
+    for (long i = 0; i < ITERATIONS; i++) {
+      final long phase1 = computeHash(i);
+      final long phase2 = computeHash(phase1);
+      final long phase3 = computeHash(phase2);
+      sum += phase3;
     }
 
-    @Test
-    public void testAndThen() throws Exception {
-        final List<String> results = new ArrayList<>(1);
-        final ComposableFuture<String> future = fromValue("hello").
-                andThen(valueTry -> results.add(valueTry.getValue()));
+    final long t2 = currentTimeMillis();
+    System.out.println("total time: " + (t2 - t1) + " for sum: " + sum);
+  }
 
-        final String value = future.get();
+  private void testWithRegularThreadPool(final boolean delegate) {
+    final List<ComposableFuture<Long>> futures = new ArrayList<>();
 
-        assertEquals("future value should be still 'hello'", "hello", value);
-        assertEquals("list should contain one result", 1, results.size());
+    for (int i = 0; i < ITERATIONS; i++) {
+      final long seed = i;
+      final ComposableFuture<Long> f1 = submit(delegate, () -> computeHash(seed));
+      final ComposableFuture<Long> f2 = f1.map(ComposableFutureTest::computeHash);
+      final ComposableFuture<Long> f3 = f2.map(ComposableFutureTest::computeHash);
+
+      futures.add(f3);
     }
 
-    @Test
-    public void testSuccessful() throws Exception {
-        final ComposableFuture<String> failureFuture = fromError(new RuntimeException("failureFuture"));
-        final ComposableFuture<Try<String>> successfulFuture = failureFuture.successful();
-
-        final Try<String> failureTry = successfulFuture.get();
-        assertTrue("Try is Failure", failureTry.isFailure());
-        assertEquals("Failure type is RuntimeException", RuntimeException.class, failureTry.getError().getClass());
+    final ComposableFuture<List<Long>> all = all(futures);
+    try {
+      final List<Long> res = all.get();
+      long sum = 0;
+      for (final long num : res) {
+        sum += num;
+      }
+    } catch (final Exception ignored) {
     }
+  }
 
-    @Test
-    public void testDelayedFuture() throws Exception {
-        final ComposableFuture<Long> successFuture = fromValue(currentTimeMillis());
-        final long timeTook = successFuture.delay(1000, MILLISECONDS).map(time -> currentTimeMillis() - time).get();
+  @Test
+  public void testContinuations() {
+    final ComposableFuture<String> res =
+        schedule(() -> "lala", 100, MILLISECONDS).alwaysWith(result -> fromError(new RuntimeException("bhaaaaa")))
+            .map(result -> "second lala")
+            .recover(error -> "third lala")
+            .recover(error -> "baaaaddddd")
+            .map(result -> {
+              throw new UncheckedExecutionException(new RuntimeException("booo"));
+            });
 
-        assertTrue("thread should have been waiting for at least 500ms (1s delay)", timeTook > 500);
+    try {
+      res.get();
+      fail("got result instead of an exception");
+    } catch (InterruptedException | ExecutionException e) {
+      final String exTypeName = e.getCause().getClass().getName();
+      assertEquals(exTypeName, RuntimeException.class.getName());
     }
+  }
 
-    @Test
-    public void testRecursive() throws Exception {
-        final AtomicInteger atomicInteger = new AtomicInteger();
-        final ComposableFuture<Integer> future = recursive(() -> fromValue(atomicInteger.incrementAndGet()), input -> input >= 10);
-        assertEquals(10, (int) future.get());
-    }
+  @Test
+  public void testComposingFutureTypes() {
+    final String name = "haim";
+    final int age = 23;
+    final double weight = 70.3;
 
-    @Test
-    public void testBatch() throws Exception {
-        final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        final ComposableFuture<List<String>> res = batch(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
-
-        final List<String> results = res.get();
-        assertEquals(results.size(), nums.size());
-
-    }
-
-    @Test
-    public void testBatchUnordered() throws Exception {
-        final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        final ComposableFuture<List<String>> res = batchUnordered(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
-
-        final List<String> results = res.get();
-        assertEquals(results.size(), nums.size());
-
-    }
-
-    @Test
-    public void testBatchToStream() throws Exception {
-        final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        final Observable<List<String>> stream = batchToStream(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
-
-        final Iterable<List<String>> iterator = stream.toBlocking().toIterable();
-        int totalElements = 0;
-        for (final List<String> batch : iterator) {
-            final int batchSize = batch.size();
-            totalElements += batchSize;
-            assertEquals(batchSize, 2);
-        }
-        assertEquals(totalElements, nums.size());
-    }
-
-    @Test
-    @Ignore("performance test")
-    public void testThreadPool() {
-        testWithRegularThreadPool(true);
-        //    testWithRegularThreadPool(false);
-    }
-
-    @Test
-    @Ignore("performance test")
-    public void testSingleThreadBenchmark() {
-        final long t1 = currentTimeMillis();
-        long sum = 0;
-
-        for (long i = 0; i < ITERATIONS; i++) {
-            final long phase1 = computeHash(i);
-            final long phase2 = computeHash(phase1);
-            final long phase3 = computeHash(phase2);
-            sum += phase3;
-        }
-
-        final long t2 = currentTimeMillis();
-        System.out.println("total time: " + (t2 - t1) + " for sum: " + sum);
-    }
-
-    private void testWithRegularThreadPool(final boolean delegate) {
-        final List<ComposableFuture<Long>> futures = new ArrayList<>();
-
-        for (int i = 0; i < ITERATIONS; i++) {
-            final long seed = i;
-            final ComposableFuture<Long> f1 = submit(delegate, () -> computeHash(seed));
-            final ComposableFuture<Long> f2 = f1.map(ComposableFutureTest::computeHash);
-            final ComposableFuture<Long> f3 = f2.map(ComposableFutureTest::computeHash);
-
-            futures.add(f3);
-        }
-
-        final ComposableFuture<List<Long>> all = all(futures);
-        try {
-            final List<Long> res = all.get();
-            long sum = 0;
-            for (final long num : res) {
-                sum += num;
-            }
-        } catch (final Exception ignored) {
-        }
-    }
-
-    @Test
-    public void testContinuations() {
-        final ComposableFuture<String> res =
-                schedule(() -> "lala", 100, MILLISECONDS).alwaysWith(result -> fromError(new RuntimeException("bhaaaaa")))
-                        .map(result -> "second lala")
-                        .recover(error -> "third lala")
-                        .recover(error -> "baaaaddddd")
-                        .map(result -> {
-                            throw new UncheckedExecutionException(new RuntimeException("booo"));
-                        });
-
-        try {
-            res.get();
-            fail("got result instead of an exception");
-        } catch (InterruptedException | ExecutionException e) {
-            final String exTypeName = e.getCause().getClass().getName();
-            assertEquals(exTypeName, RuntimeException.class.getName());
-        }
-    }
-
-    @Test
-    public void testComposingFutureTypes() {
-        final String name = "haim";
-        final int age = 23;
-        final double weight = 70.3;
-
-        final ComposableFuture<String> futureName = fromValue(name);
-        final ComposableFuture<Integer> futureAge = fromValue(age);
-        final ComposableFuture<Double> futureWeight = fromValue(weight);
+    final ComposableFuture<String> futureName = fromValue(name);
+    final ComposableFuture<Integer> futureAge = fromValue(age);
+    final ComposableFuture<Double> futureWeight = fromValue(weight);
 
 //      final ComposableFuture<Double> weight = fromError(new RuntimeException("Illegal Weight error!"));
 
-        final ComposableFuture<Person> person = combine(futureName, futureAge, futureWeight,
-                (TriFunction<String, Integer, Double, Person>) (name1, age1, weight1) -> new Person(age1, name1, weight1));
+    final ComposableFuture<Person> person = combine(futureName, futureAge, futureWeight,
+        (TriFunction<String, Integer, Double, Person>) (name1, age1, weight1) -> new Person(age1, name1, weight1));
 
-        try {
-            final Person result = person.get();
-            assertEquals(result.age, age);
-            assertEquals(result.name, name);
-            assertEquals(result.weight, weight, 0);
-        } catch (InterruptedException | ExecutionException e) {
-            fail(e.getMessage());
-        }
-
-        final ComposableFuture<String> first = fromValue("1");
-        final ComposableFuture<Integer> second = fromValue(2);
-        final ComposableFuture<Object> badRes = combine(first, second,
-                (BiFunction<String, Integer, Object>) (left, right) -> {
-                    throw new ExecutionException(new RuntimeException("not the same..."));
-                });
-
-        try {
-            badRes.get();
-            fail("should get an error");
-        } catch (final InterruptedException e) {
-            fail(e.getMessage());
-        } catch (final ExecutionException e) {
-            assertTrue(e.getCause().getMessage().contains("not the same..."));
-        }
-
+    try {
+      final Person result = person.get();
+      assertEquals(result.age, age);
+      assertEquals(result.name, name);
+      assertEquals(result.weight, weight, 0);
+    } catch (InterruptedException | ExecutionException e) {
+      fail(e.getMessage());
     }
 
-    @Test
-    public void testCatchingThrowable() throws Exception {
-        final ComposableFuture<Object> failedFuture = fromValue("Success").map(__ -> {
-            throw new OutOfMemoryError();
+    final ComposableFuture<String> first = fromValue("1");
+    final ComposableFuture<Integer> second = fromValue(2);
+    final ComposableFuture<Object> badRes = combine(first, second,
+        (BiFunction<String, Integer, Object>) (left, right) -> {
+          throw new ExecutionException(new RuntimeException("not the same..."));
         });
 
-        final AtomicReference<Boolean> failed = new AtomicReference<>(false);
-        final CountDownLatch latch = new CountDownLatch(1);
-        failedFuture.consume(result -> {
-            failed.set(result.isFailure());
-            latch.countDown();
-        });
-
-        latch.await();
-
-        assertTrue("consume should be called, with try of OutOfMemoryError", failed.get());
+    try {
+      badRes.get();
+      fail("should get an error");
+    } catch (final InterruptedException e) {
+      fail(e.getMessage());
+    } catch (final ExecutionException e) {
+      assertTrue(e.getCause().getMessage().contains("not the same..."));
     }
 
-    @Test
-    public void testSlowFuture() {
-        final ComposableFuture<String> f1 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
+  }
 
-        final ComposableFuture<String> f2 = fromValue("fast1");
-        final ComposableFuture<String> f3 = fromValue("fast2");
+  @Test
+  public void testCatchingThrowable() throws Exception {
+    final ComposableFuture<Object> failedFuture = fromValue("Success").map(__ -> {
+      throw new OutOfMemoryError();
+    });
 
-        final ComposableFuture<List<String>> res = all(Arrays.asList(f1, f2, f3));
-        final long t1 = currentTimeMillis();
-        try {
-            res.get();
-            final long t2 = currentTimeMillis();
-            assertTrue("time is: " + (t2 - t1), (t2 - t1) > 900); // not
-        } catch (InterruptedException | ExecutionException e) {
-            fail(e.getMessage());
-        }
+    final AtomicReference<Boolean> failed = new AtomicReference<>(false);
+    final CountDownLatch latch = new CountDownLatch(1);
+    failedFuture.consume(result -> {
+      failed.set(result.isFailure());
+      latch.countDown();
+    });
 
-        final ComposableFuture<String> f4 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
-        final ComposableFuture<String> f5 = fromError(new RuntimeException("oops"));
-        final ComposableFuture<List<String>> res2 = all(true, Arrays.asList(f4, f5));
-        final long t3 = currentTimeMillis();
-        try {
-            res2.get();
-            fail("should get error.");
-        } catch (InterruptedException | ExecutionException e) {
-            final long t4 = currentTimeMillis();
-            assertTrue((t4 - t3) < 100);
-        }
+    latch.await();
 
-        final ComposableFuture<String> f6 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
-        final ComposableFuture<String> f7 = fromError(new RuntimeException("oops"));
-        final ComposableFuture<List<String>> res3 = all(true, Arrays.asList(f6, f7));
-        final long t5 = currentTimeMillis();
-        try {
-            res3.get();
-            fail("should get error.");
-        } catch (InterruptedException | ExecutionException e) {
-            final long t6 = currentTimeMillis();
-            System.out.println("time took to fail: " + (t6 - t5));
-            assertTrue((t6 - t5) < 100);
-        }
+    assertTrue("consume should be called, with try of OutOfMemoryError", failed.get());
+  }
 
+  @Test
+  public void testSlowFuture() {
+    final ComposableFuture<String> f1 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
+
+    final ComposableFuture<String> f2 = fromValue("fast1");
+    final ComposableFuture<String> f3 = fromValue("fast2");
+
+    final ComposableFuture<List<String>> res = all(Arrays.asList(f1, f2, f3));
+    final long t1 = currentTimeMillis();
+    try {
+      res.get();
+      final long t2 = currentTimeMillis();
+      assertTrue("time is: " + (t2 - t1), (t2 - t1) > 900); // not
+    } catch (InterruptedException | ExecutionException e) {
+      fail(e.getMessage());
     }
 
-    @SuppressWarnings("Convert2MethodRef")
-    @Test
-    public void testFuturesToStream() throws InterruptedException {
-        final ComposableFuture<Long> first = schedule(() -> currentTimeMillis(), 1, TimeUnit.SECONDS);
+    final ComposableFuture<String> f4 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
+    final ComposableFuture<String> f5 = fromError(new RuntimeException("oops"));
+    final ComposableFuture<List<String>> res2 = all(true, Arrays.asList(f4, f5));
+    final long t3 = currentTimeMillis();
+    try {
+      res2.get();
+      fail("should get error.");
+    } catch (InterruptedException | ExecutionException e) {
+      final long t4 = currentTimeMillis();
+      assertTrue((t4 - t3) < 100);
+    }
 
-        final ComposableFuture<Long> second = schedule(() -> currentTimeMillis(), 2, TimeUnit.SECONDS);
+    final ComposableFuture<String> f6 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
+    final ComposableFuture<String> f7 = fromError(new RuntimeException("oops"));
+    final ComposableFuture<List<String>> res3 = all(true, Arrays.asList(f6, f7));
+    final long t5 = currentTimeMillis();
+    try {
+      res3.get();
+      fail("should get error.");
+    } catch (InterruptedException | ExecutionException e) {
+      final long t6 = currentTimeMillis();
+      System.out.println("time took to fail: " + (t6 - t5));
+      assertTrue((t6 - t5) < 100);
+    }
 
-        final ComposableFuture<Long> third = schedule(() -> currentTimeMillis(), 3, TimeUnit.SECONDS);
+  }
 
-        final Iterable<Long> events = toHotObservable(Arrays.asList(first, second, third), true).toBlocking().toIterable();
-        long prevEvent = 0;
-        int counter = 0;
-        for (final Long event : events) {
-            counter++;
-            assertTrue("event should have bigger timestamp than the previous one", event > prevEvent);
-            prevEvent = event;
+  @SuppressWarnings("Convert2MethodRef")
+  @Test
+  public void testFuturesToStream() throws InterruptedException {
+    final ComposableFuture<Long> first = schedule(() -> currentTimeMillis(), 1, TimeUnit.SECONDS);
+
+    final ComposableFuture<Long> second = schedule(() -> currentTimeMillis(), 2, TimeUnit.SECONDS);
+
+    final ComposableFuture<Long> third = schedule(() -> currentTimeMillis(), 3, TimeUnit.SECONDS);
+
+    final Iterable<Long> events = toHotObservable(Arrays.asList(first, second, third), true).toBlocking().toIterable();
+    long prevEvent = 0;
+    int counter = 0;
+    for (final Long event : events) {
+      counter++;
+      assertTrue("event should have bigger timestamp than the previous one", event > prevEvent);
+      prevEvent = event;
+    }
+
+    assertEquals("should receive 3 events", counter, 3);
+
+  }
+
+  @Test
+  public void testFutureProviderToStream() {
+    final Observable<Long> stream = toObservable(new FutureProvider<Long>() {
+      private volatile int index = 3;
+      private volatile ComposableFuture<Long> currentRes;
+
+      @SuppressWarnings("Convert2MethodRef")
+      @Override
+      public boolean moveNext() {
+        if (index > 0) {
+          index--;
+          currentRes = schedule(() -> currentTimeMillis(), 100, MILLISECONDS);
+
+          return true;
+        } else {
+          return false;
         }
+      }
 
-        assertEquals("should receive 3 events", counter, 3);
+      @Override
+      public ComposableFuture<Long> current() {
+        return currentRes;
+      }
+    });
 
+    long current = currentTimeMillis();
+    final Iterable<Long> events = stream.toBlocking().toIterable();
+    int counter = 0;
+    for (final Long event : events) {
+      assertTrue(event > current);
+      current = event;
+      counter++;
     }
 
-    @Test
-    public void testFutureProviderToStream() {
-        final Observable<Long> stream = toObservable(new FutureProvider<Long>() {
-            private volatile int index = 3;
-            private volatile ComposableFuture<Long> currentRes;
+    assertTrue(counter == 3);
 
-            @SuppressWarnings("Convert2MethodRef")
-            @Override
-            public boolean moveNext() {
-                if (index > 0) {
-                    index--;
-                    currentRes = schedule(() -> currentTimeMillis(), 100, MILLISECONDS);
+  }
 
-                    return true;
-                } else {
-                    return false;
-                }
-            }
+  @Test
+  public void testFirstNoTimeout() throws Exception {
+    final PassThroughCount passThroughCount = new PassThroughCount(3);
+    try {
+      final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
 
-            @Override
-            public ComposableFuture<Long> current() {
-                return currentRes;
-            }
-        });
+      final Map<String, String> res = first(elements, 3).get();
+      assertEquals(3, res.size());
+      assertEquals("one", res.get("one"));
+      assertEquals("two", res.get("two"));
+      assertEquals("three", res.get("three"));
+    } finally {
+      passThroughCount.releaseAllWaiters(); // release last two guys
+    }
+  }
 
-        long current = currentTimeMillis();
-        final Iterable<Long> events = stream.toBlocking().toIterable();
-        int counter = 0;
-        for (final Long event : events) {
-            assertTrue(event > current);
-            current = event;
-            counter++;
-        }
+  @Test
+  public void testFirstWithTimeout() throws Exception {
+    final PassThroughCount passThroughCount = new PassThroughCount(2);
+    try {
+      final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+      passThroughCount.waitForPassers();  // we do not want that the first two elements will not finish due to scheduling issues
+      final Map<String, String> res = first(elements, 3, 10, MILLISECONDS).get();
 
-        assertTrue(counter == 3);
+      assertEquals(2, res.size());
+      assertEquals("one", res.get("one"));
+      assertEquals("two", res.get("two"));
+    } finally {
+      passThroughCount.releaseAllWaiters(); // release last two guys
+    }
+  }
 
+  @Test
+  public void testAllFailOnError() throws Exception {
+    final PassThroughCount passThroughCount = new PassThroughCount(5);
+    final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+
+    try {
+      all(true, elements).get();
+      fail("should get an exception");
+    } catch (final ExecutionException e) {
+      assertTrue(e.getCause().getMessage().contains("bad element"));
+    } finally {
+      passThroughCount.releaseAllWaiters(); // release last two guys
     }
 
-    @Test
-    public void testFirstNoTimeout() throws Exception {
-        final PassThroughCount passThroughCount = new PassThroughCount(3);
-        try {
-            final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+  }
 
-            final Map<String, String> res = first(elements, 3).get();
-            assertEquals(3, res.size());
-            assertEquals("one", res.get("one"));
-            assertEquals("two", res.get("two"));
-            assertEquals("three", res.get("three"));
-        } finally {
-            passThroughCount.releaseAllWaiters(); // release last two guys
-        }
+  @Test
+  public void testAllFailFast() throws Exception {
+    final Map<String, ComposableFuture<String>> elements = new HashMap<>();
+
+    elements.put("one", submit(() -> {
+      Thread.sleep(100);
+      return "one";
+    }));
+
+    elements.put("two", submit(() -> {
+      throw new RuntimeException("error...");
+    }));
+
+    final long t1 = currentTimeMillis();
+    try {
+      all(true, elements).get();
+      fail("should fail");
+    } catch (final ExecutionException e) {
+      final long t2 = currentTimeMillis();
+      assertTrue("should fail fast", (t2 - t1) < 50);
+    }
+  }
+
+  private Map<String, ComposableFuture<String>> createElementsMap(final PassThroughCount passThroughCount) {
+    final Map<String, ComposableFuture<String>> elements = new HashMap<>();
+
+    elements.put("one", submit(() -> {
+      passThroughCount.awaitOrPass(1);
+      return "one";
+    }));
+    elements.put("two", submit(() -> {
+      passThroughCount.awaitOrPass(2);
+      return "two";
+    }));
+    elements.put("three", submit(() -> {
+      passThroughCount.awaitOrPass(3);
+      return "three";
+    }));
+    elements.put("four", submit(() -> {
+      passThroughCount.awaitOrPass(4);
+      throw new RuntimeException("bad element");
+    }));
+    elements.put("five", submit(() -> {
+      passThroughCount.awaitOrPass(5);
+      return "five";
+    }));
+    return elements;
+  }
+
+  @Test
+  public void testTypedErrors() throws Exception {
+    String result = ComposableFutures.<String>submit(() -> {
+      throw new FileNotFoundException("no file...");
+    }).recover(NullPointerException.class, error -> {
+      return "failure";
+    }).recover(FileNotFoundException.class, error -> {
+      return "success";
+    }).recover(error -> {
+      return "failure";
+    }).get();
+
+    Assert.assertEquals("success", result);
+
+    String result2 = ComposableFutures.<String>submit(() -> {
+      throw new FileNotFoundException("no file...");
+    }).recoverWith(NullPointerException.class, error -> {
+      return ComposableFutures.fromValue("failure");
+    }).recoverWith(FileNotFoundException.class, error -> {
+      return ComposableFutures.fromValue("success");
+    }).recoverWith(error -> {
+      return ComposableFutures.fromValue("failure");
+    }).get();
+
+    Assert.assertEquals("success", result2);
+
+  }
+
+  @Test
+  public void testWithTimeout() throws Exception {
+    final String RES_STR = "result";
+    final EagerComposableFuture<String> value = new EagerComposableFuture<>();
+
+    final ComposableFuture<String> effectiveValue = value.withTimeout(100, MILLISECONDS);
+    Thread.sleep(50);
+    value.set(RES_STR);
+    assertEquals(RES_STR, value.get());
+    assertEquals(RES_STR, effectiveValue.get());
+
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void testWithTimeoutExpired() throws Exception {
+    final String RES_STR = "result";
+    final EagerComposableFuture<String> value = new EagerComposableFuture<>();
+
+    final ComposableFuture<String> effectiveValue = value.withTimeout(50, MILLISECONDS);
+    Thread.sleep(100);
+    value.set(RES_STR);
+    assertEquals(RES_STR, value.get());
+    effectiveValue.get(); // this should throw an exception
+  }
+
+  private static final class Person {
+    public final int age;
+    public final String name;
+    public final double weight;
+
+
+    private Person(final int age, final String name, final double weight) {
+      this.age = age;
+      this.name = name;
+      this.weight = weight;
+    }
+  }
+
+  class PassThroughCount {
+    final CountDownLatch waitersLatch;
+    final CountDownLatch passersLatch;
+    final int numToPass;
+
+    public PassThroughCount(final int numToPass) {
+      waitersLatch = new CountDownLatch(1);
+      passersLatch = new CountDownLatch(numToPass);
+      this.numToPass = numToPass;
     }
 
-    @Test
-    public void testFirstWithTimeout() throws Exception {
-        final PassThroughCount passThroughCount = new PassThroughCount(2);
-        try {
-            final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
-            passThroughCount.waitForPassers();  // we do not want that the first two elements will not finish due to scheduling issues
-            final Map<String, String> res = first(elements, 3, 10, MILLISECONDS).get();
-
-            assertEquals(2, res.size());
-            assertEquals("one", res.get("one"));
-            assertEquals("two", res.get("two"));
-        } finally {
-            passThroughCount.releaseAllWaiters(); // release last two guys
-        }
+    public void awaitOrPass(final long myOrder) throws InterruptedException {
+      if (myOrder > numToPass) waitersLatch.await();
+      else passersLatch.countDown();
     }
 
-    @Test
-    public void testAllFailOnError() throws Exception {
-        final PassThroughCount passThroughCount = new PassThroughCount(5);
-        final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
-
-        try {
-            all(true, elements).get();
-            fail("should get an exception");
-        } catch (final ExecutionException e) {
-            assertTrue(e.getCause().getMessage().contains("bad element"));
-        } finally {
-            passThroughCount.releaseAllWaiters(); // release last two guys
-        }
-
+    public void releaseAllWaiters() {
+      waitersLatch.countDown();
     }
 
-    @Test
-    public void testAllFailFast() throws Exception {
-        final Map<String, ComposableFuture<String>> elements = new HashMap<>();
-
-        elements.put("one", submit(() -> {
-            Thread.sleep(100);
-            return "one";
-        }));
-
-        elements.put("two", submit(() -> {
-            throw new RuntimeException("error...");
-        }));
-
-        final long t1 = currentTimeMillis();
-        try {
-            all(true, elements).get();
-            fail("should fail");
-        } catch (final ExecutionException e) {
-            final long t2 = currentTimeMillis();
-            assertTrue("should fail fast", (t2 - t1) < 50);
-        }
+    public void waitForPassers() throws InterruptedException {
+      passersLatch.await();
     }
-
-    private Map<String, ComposableFuture<String>> createElementsMap(final PassThroughCount passThroughCount) {
-        final Map<String, ComposableFuture<String>> elements = new HashMap<>();
-
-        elements.put("one", submit(() -> {
-            passThroughCount.awaitOrPass(1);
-            return "one";
-        }));
-        elements.put("two", submit(() -> {
-            passThroughCount.awaitOrPass(2);
-            return "two";
-        }));
-        elements.put("three", submit(() -> {
-            passThroughCount.awaitOrPass(3);
-            return "three";
-        }));
-        elements.put("four", submit(() -> {
-            passThroughCount.awaitOrPass(4);
-            throw new RuntimeException("bad element");
-        }));
-        elements.put("five", submit(() -> {
-            passThroughCount.awaitOrPass(5);
-            return "five";
-        }));
-        return elements;
-    }
-
-    @Test
-    public void testTypedErrors() throws Exception {
-        String result = ComposableFutures.<String>submit(() -> {
-            throw new FileNotFoundException("no file...");
-        }).recover(NullPointerException.class, error -> {
-            return "failure";
-        }).recover(FileNotFoundException.class, error -> {
-            return "success";
-        }).recover(error -> {
-            return "failure";
-        }).get();
-
-        Assert.assertEquals("success", result);
-
-        String result2 = ComposableFutures.<String>submit(() -> {
-            throw new FileNotFoundException("no file...");
-        }).recoverWith(NullPointerException.class, error -> {
-            return ComposableFutures.fromValue("failure");
-        }).recoverWith(FileNotFoundException.class, error -> {
-            return ComposableFutures.fromValue("success");
-        }).recoverWith(error -> {
-            return ComposableFutures.fromValue("failure");
-        }).get();
-
-        Assert.assertEquals("success", result2);
-
-    }
-
-    @Test
-    public void testWithTimeout() throws Exception {
-        final String RES_STR = "result";
-        final EagerComposableFuture<String> value = new EagerComposableFuture<>();
-
-        final ComposableFuture<String> effectiveValue = value.withTimeout(100, MILLISECONDS);
-        Thread.sleep(50);
-        value.set(RES_STR);
-        assertEquals(RES_STR, value.get());
-        assertEquals(RES_STR, effectiveValue.get());
-
-    }
-
-    @Test(expected = ExecutionException.class)
-    public void testWithTimeoutExpired() throws Exception {
-        final String RES_STR = "result";
-        final EagerComposableFuture<String> value = new EagerComposableFuture<>();
-
-        final ComposableFuture<String> effectiveValue = value.withTimeout(50, MILLISECONDS);
-        Thread.sleep(100);
-        value.set(RES_STR);
-        assertEquals(RES_STR, value.get());
-        effectiveValue.get(); // this should throw an exception
-    }
-
-    private static final class Person {
-        public final int age;
-        public final String name;
-        public final double weight;
-
-
-        private Person(final int age, final String name, final double weight) {
-            this.age = age;
-            this.name = name;
-            this.weight = weight;
-        }
-    }
-
-    class PassThroughCount {
-        final CountDownLatch waitersLatch;
-        final CountDownLatch passersLatch;
-        final int numToPass;
-
-        public PassThroughCount(final int numToPass) {
-            waitersLatch = new CountDownLatch(1);
-            passersLatch = new CountDownLatch(numToPass);
-            this.numToPass = numToPass;
-        }
-
-        public void awaitOrPass(final long myOrder) throws InterruptedException {
-            if (myOrder > numToPass) waitersLatch.await();
-            else passersLatch.countDown();
-        }
-
-        public void releaseAllWaiters() {
-            waitersLatch.countDown();
-        }
-
-        public void waitForPassers() throws InterruptedException {
-            passersLatch.await();
-        }
-    }
+  }
 
 }

--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/ComposableFutureTest.java
@@ -1,5 +1,6 @@
 package com.outbrain.ob1k.concurrent;
 
+import java.io.FileNotFoundException;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -12,6 +13,7 @@ import com.outbrain.ob1k.concurrent.combiners.TriFunction;
 import com.outbrain.ob1k.concurrent.eager.EagerComposableFuture;
 import com.outbrain.ob1k.concurrent.handlers.*;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -29,523 +31,551 @@ import static org.junit.Assert.*;
  */
 public class ComposableFutureTest {
 
-  public static final int ITERATIONS = 100000;
+    private static final int ITERATIONS = 100000;
 
-  private static long computeHash(final long seed) {
-    long value = seed;
-    for (int i = 0; i < 10000; i++) {
-      value ^= value << 13;
-      value ^= value >>> 17;
-      value ^= value << 5;
+    private static long computeHash(final long seed) {
+        long value = seed;
+        for (int i = 0; i < 10000; i++) {
+            value ^= value << 13;
+            value ^= value >>> 17;
+            value ^= value << 5;
+        }
+
+        return value;
     }
 
-    return value;
-  }
+    @Test
+    public void testForeach() throws ExecutionException, InterruptedException {
+        final List<Integer> numbers = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            numbers.add(i);
+        }
 
-  @Test
-  public void testForeach() throws ExecutionException, InterruptedException {
-    final List<Integer> numbers = new ArrayList<>();
-    for (int i = 1; i <= 10; i++) {
-      numbers.add(i);
-    }
+        final List<Integer> empty = new ArrayList<>();
+        final ComposableFuture<List<Integer>> first3Even = foreach(numbers, empty, (element, aggregateResult) -> {
+            if (aggregateResult.size() < 3 && element % 2 == 0) {
+                aggregateResult.add(element);
+            }
 
-    final List<Integer> empty = new ArrayList<>();
-    final ComposableFuture<List<Integer>> first3Even = foreach(numbers, empty, (element, aggregateResult) -> {
-      if (aggregateResult.size() < 3 && element % 2 == 0) {
-        aggregateResult.add(element);
-      }
-
-      return fromValue(aggregateResult);
-    });
-
-    final List<Integer> result = first3Even.get();
-    assertEquals(result.size(), 3);
-    assertEquals(result.get(0), new Integer(2));
-    assertEquals(result.get(1), new Integer(4));
-    assertEquals(result.get(2), new Integer(6));
-  }
-
-  @Test
-  public void testRepeat() throws Exception {
-    final ComposableFuture<Integer> future = repeat(10, 0, result -> fromValue(result + 1));
-    assertEquals(10, (int) future.get());
-  }
-
-  @Test
-  public void testEnsure() throws Exception {
-    final ComposableFuture<String> future = fromValue("hello").ensure(String::isEmpty);
-    try {
-      future.get();
-    } catch (final ExecutionException e) {
-      assertEquals("ensure failed the chain with NoSuchElementException",
-        NoSuchElementException.class, e.getCause().getClass());
-      return;
-    }
-
-    fail("exception should have been thrown");
-  }
-
-  @Test
-  public void testAndThen() throws Exception {
-    final List<String> results = new ArrayList<>(1);
-    final ComposableFuture<String> future = fromValue("hello").
-      andThen(valueTry -> results.add(valueTry.getValue()));
-
-    final String value = future.get();
-
-    assertEquals("future value should be still 'hello'", "hello", value);
-    assertEquals("list should contain one result", 1, results.size());
-  }
-
-  @Test
-  public void testSuccessful() throws Exception {
-    final ComposableFuture<String> failureFuture = fromError(new RuntimeException("failureFuture"));
-    final ComposableFuture<Try<String>> successfulFuture = failureFuture.successful();
-
-    final Try<String> failureTry = successfulFuture.get();
-    assertTrue("Try is Failure", failureTry.isFailure());
-    assertEquals("Failure type is RuntimeException", RuntimeException.class, failureTry.getError().getClass());
-  }
-
-  @Test
-  public void testDelayedFuture() throws Exception {
-    final ComposableFuture<Long> successFuture = fromValue(currentTimeMillis());
-    final long timeTook = successFuture.delay(1000, MILLISECONDS).map(time -> currentTimeMillis() - time).get();
-
-    assertTrue("thread should have been waiting for at least 500ms (1s delay)", timeTook > 500);
-  }
-
-  @Test
-  public void testRecursive() throws Exception {
-    final AtomicInteger atomicInteger = new AtomicInteger();
-    final ComposableFuture<Integer> future = recursive(() -> fromValue(atomicInteger.incrementAndGet()), input -> input >= 10);
-    assertEquals(10, (int) future.get());
-  }
-
-  @Test
-  public void testBatch() throws Exception {
-    final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    final ComposableFuture<List<String>> res = batch(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
-
-    final List<String> results = res.get();
-    assertEquals(results.size(), nums.size());
-
-  }
-
-  @Test
-  public void testBatchUnordered() throws Exception {
-    final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    final ComposableFuture<List<String>> res = batchUnordered(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
-
-    final List<String> results = res.get();
-    assertEquals(results.size(), nums.size());
-
-  }
-
-  @Test
-  public void testBatchToStream() throws Exception {
-    final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    final Observable<List<String>> stream = batchToStream(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
-
-    final Iterable<List<String>> iterator = stream.toBlocking().toIterable();
-    int totalElements = 0;
-    for (final List<String> batch : iterator) {
-      final int batchSize = batch.size();
-      totalElements += batchSize;
-      assertEquals(batchSize, 2);
-    }
-    assertEquals(totalElements, nums.size());
-  }
-
-  @Test
-  @Ignore("performance test")
-  public void testThreadPool() {
-    testWithRegularThreadPool(true);
-    //    testWithRegularThreadPool(false);
-  }
-
-  @Test
-  @Ignore("performance test")
-  public void testSingleThreadBenchmark() {
-    final long t1 = currentTimeMillis();
-    long sum = 0;
-
-    for (long i = 0; i < ITERATIONS; i++) {
-      final long phase1 = computeHash(i);
-      final long phase2 = computeHash(phase1);
-      final long phase3 = computeHash(phase2);
-      sum += phase3;
-    }
-
-    final long t2 = currentTimeMillis();
-    System.out.println("total time: " + (t2 - t1) + " for sum: " + sum);
-  }
-
-  private void testWithRegularThreadPool(final boolean delegate) {
-    final List<ComposableFuture<Long>> futures = new ArrayList<>();
-
-    for (int i = 0; i < ITERATIONS; i++) {
-      final long seed = i;
-      final ComposableFuture<Long> f1 = submit(delegate, () -> computeHash(seed));
-      final ComposableFuture<Long> f2 = f1.map(ComposableFutureTest::computeHash);
-      final ComposableFuture<Long> f3 = f2.map(ComposableFutureTest::computeHash);
-
-      futures.add(f3);
-    }
-
-    final ComposableFuture<List<Long>> all = all(futures);
-    try {
-      final List<Long> res = all.get();
-      long sum = 0;
-      for (final long num : res) {
-        sum += num;
-      }
-    } catch (final Exception ignored) {
-    }
-  }
-
-  @Test
-  public void testContinuations() {
-    final ComposableFuture<String> res =
-      schedule(() -> "lala", 100, MILLISECONDS).alwaysWith(result -> fromError(new RuntimeException("bhaaaaa")))
-        .map(result -> "second lala")
-        .recover(error -> "third lala")
-        .recover(error -> "baaaaddddd")
-        .map(result -> {
-          throw new UncheckedExecutionException(new RuntimeException("booo"));
+            return fromValue(aggregateResult);
         });
 
-    try {
-      res.get();
-      fail("got result instead of an exception");
-    } catch (InterruptedException | ExecutionException e) {
-      final String exTypeName = e.getCause().getClass().getName();
-      assertEquals(exTypeName, RuntimeException.class.getName());
+        final List<Integer> result = first3Even.get();
+        assertEquals(result.size(), 3);
+        assertEquals(result.get(0), new Integer(2));
+        assertEquals(result.get(1), new Integer(4));
+        assertEquals(result.get(2), new Integer(6));
     }
-  }
 
-  @Test
-  public void testComposingFutureTypes() {
-    final String name = "haim";
-    final int age = 23;
-    final double weight = 70.3;
+    @Test
+    public void testRepeat() throws Exception {
+        final ComposableFuture<Integer> future = repeat(10, 0, result -> fromValue(result + 1));
+        assertEquals(10, (int) future.get());
+    }
 
-    final ComposableFuture<String> futureName = fromValue(name);
-    final ComposableFuture<Integer> futureAge = fromValue(age);
-    final ComposableFuture<Double> futureWeight = fromValue(weight);
+    @Test
+    public void testEnsure() throws Exception {
+        final ComposableFuture<String> future = fromValue("hello").ensure(String::isEmpty);
+        try {
+            future.get();
+        } catch (final ExecutionException e) {
+            assertEquals("ensure failed the chain with NoSuchElementException",
+                    NoSuchElementException.class, e.getCause().getClass());
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+
+    @Test
+    public void testAndThen() throws Exception {
+        final List<String> results = new ArrayList<>(1);
+        final ComposableFuture<String> future = fromValue("hello").
+                andThen(valueTry -> results.add(valueTry.getValue()));
+
+        final String value = future.get();
+
+        assertEquals("future value should be still 'hello'", "hello", value);
+        assertEquals("list should contain one result", 1, results.size());
+    }
+
+    @Test
+    public void testSuccessful() throws Exception {
+        final ComposableFuture<String> failureFuture = fromError(new RuntimeException("failureFuture"));
+        final ComposableFuture<Try<String>> successfulFuture = failureFuture.successful();
+
+        final Try<String> failureTry = successfulFuture.get();
+        assertTrue("Try is Failure", failureTry.isFailure());
+        assertEquals("Failure type is RuntimeException", RuntimeException.class, failureTry.getError().getClass());
+    }
+
+    @Test
+    public void testDelayedFuture() throws Exception {
+        final ComposableFuture<Long> successFuture = fromValue(currentTimeMillis());
+        final long timeTook = successFuture.delay(1000, MILLISECONDS).map(time -> currentTimeMillis() - time).get();
+
+        assertTrue("thread should have been waiting for at least 500ms (1s delay)", timeTook > 500);
+    }
+
+    @Test
+    public void testRecursive() throws Exception {
+        final AtomicInteger atomicInteger = new AtomicInteger();
+        final ComposableFuture<Integer> future = recursive(() -> fromValue(atomicInteger.incrementAndGet()), input -> input >= 10);
+        assertEquals(10, (int) future.get());
+    }
+
+    @Test
+    public void testBatch() throws Exception {
+        final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        final ComposableFuture<List<String>> res = batch(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
+
+        final List<String> results = res.get();
+        assertEquals(results.size(), nums.size());
+
+    }
+
+    @Test
+    public void testBatchUnordered() throws Exception {
+        final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        final ComposableFuture<List<String>> res = batchUnordered(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
+
+        final List<String> results = res.get();
+        assertEquals(results.size(), nums.size());
+
+    }
+
+    @Test
+    public void testBatchToStream() throws Exception {
+        final List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        final Observable<List<String>> stream = batchToStream(nums, 2, result -> schedule(() -> "num:" + result, 1, TimeUnit.SECONDS));
+
+        final Iterable<List<String>> iterator = stream.toBlocking().toIterable();
+        int totalElements = 0;
+        for (final List<String> batch : iterator) {
+            final int batchSize = batch.size();
+            totalElements += batchSize;
+            assertEquals(batchSize, 2);
+        }
+        assertEquals(totalElements, nums.size());
+    }
+
+    @Test
+    @Ignore("performance test")
+    public void testThreadPool() {
+        testWithRegularThreadPool(true);
+        //    testWithRegularThreadPool(false);
+    }
+
+    @Test
+    @Ignore("performance test")
+    public void testSingleThreadBenchmark() {
+        final long t1 = currentTimeMillis();
+        long sum = 0;
+
+        for (long i = 0; i < ITERATIONS; i++) {
+            final long phase1 = computeHash(i);
+            final long phase2 = computeHash(phase1);
+            final long phase3 = computeHash(phase2);
+            sum += phase3;
+        }
+
+        final long t2 = currentTimeMillis();
+        System.out.println("total time: " + (t2 - t1) + " for sum: " + sum);
+    }
+
+    private void testWithRegularThreadPool(final boolean delegate) {
+        final List<ComposableFuture<Long>> futures = new ArrayList<>();
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            final long seed = i;
+            final ComposableFuture<Long> f1 = submit(delegate, () -> computeHash(seed));
+            final ComposableFuture<Long> f2 = f1.map(ComposableFutureTest::computeHash);
+            final ComposableFuture<Long> f3 = f2.map(ComposableFutureTest::computeHash);
+
+            futures.add(f3);
+        }
+
+        final ComposableFuture<List<Long>> all = all(futures);
+        try {
+            final List<Long> res = all.get();
+            long sum = 0;
+            for (final long num : res) {
+                sum += num;
+            }
+        } catch (final Exception ignored) {
+        }
+    }
+
+    @Test
+    public void testContinuations() {
+        final ComposableFuture<String> res =
+                schedule(() -> "lala", 100, MILLISECONDS).alwaysWith(result -> fromError(new RuntimeException("bhaaaaa")))
+                        .map(result -> "second lala")
+                        .recover(error -> "third lala")
+                        .recover(error -> "baaaaddddd")
+                        .map(result -> {
+                            throw new UncheckedExecutionException(new RuntimeException("booo"));
+                        });
+
+        try {
+            res.get();
+            fail("got result instead of an exception");
+        } catch (InterruptedException | ExecutionException e) {
+            final String exTypeName = e.getCause().getClass().getName();
+            assertEquals(exTypeName, RuntimeException.class.getName());
+        }
+    }
+
+    @Test
+    public void testComposingFutureTypes() {
+        final String name = "haim";
+        final int age = 23;
+        final double weight = 70.3;
+
+        final ComposableFuture<String> futureName = fromValue(name);
+        final ComposableFuture<Integer> futureAge = fromValue(age);
+        final ComposableFuture<Double> futureWeight = fromValue(weight);
 
 //      final ComposableFuture<Double> weight = fromError(new RuntimeException("Illegal Weight error!"));
 
-    final ComposableFuture<Person> person = combine(futureName, futureAge, futureWeight, 
-      (TriFunction<String, Integer, Double, Person>) (name1, age1, weight1) -> new Person(age1, name1, weight1));
+        final ComposableFuture<Person> person = combine(futureName, futureAge, futureWeight,
+                (TriFunction<String, Integer, Double, Person>) (name1, age1, weight1) -> new Person(age1, name1, weight1));
 
-    try {
-      final Person result = person.get();
-      assertEquals(result.age, age);
-      assertEquals(result.name, name);
-      assertEquals(result.weight, weight, 0);
-    } catch (InterruptedException | ExecutionException e) {
-      fail(e.getMessage());
-    }
-
-    final ComposableFuture<String> first = fromValue("1");
-    final ComposableFuture<Integer> second = fromValue(2);
-    final ComposableFuture<Object> badRes = combine(first, second,
-      (BiFunction<String, Integer, Object>) (left, right) -> {
-        throw new ExecutionException(new RuntimeException("not the same..."));
-      });
-
-    try {
-      badRes.get();
-      fail("should get an error");
-    } catch (final InterruptedException e) {
-      fail(e.getMessage());
-    } catch (final ExecutionException e) {
-      assertTrue(e.getCause().getMessage().contains("not the same..."));
-    }
-
-  }
-  
-  @Test
-  public void testCatchingThrowable() throws Exception {
-    final ComposableFuture<Object> failedFuture = fromValue("Success").map(__ -> {
-      throw new OutOfMemoryError();
-    });
-
-    final AtomicReference<Boolean> failed = new AtomicReference<>(false);
-    final CountDownLatch latch = new CountDownLatch(1);
-    failedFuture.consume(result -> {
-      failed.set(result.isFailure());
-      latch.countDown();
-    });
-
-    latch.await();
-
-    assertTrue("consume should be called, with try of OutOfMemoryError", failed.get());
-  }
-
-  @Test
-  public void testSlowFuture() {
-    final ComposableFuture<String> f1 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
-
-    final ComposableFuture<String> f2 = fromValue("fast1");
-    final ComposableFuture<String> f3 = fromValue("fast2");
-
-    final ComposableFuture<List<String>> res = all(Arrays.asList(f1, f2, f3));
-    final long t1 = currentTimeMillis();
-    try {
-      res.get();
-      final long t2 = currentTimeMillis();
-      assertTrue("time is: " + (t2 - t1), (t2 - t1) > 900); // not
-    } catch (InterruptedException | ExecutionException e) {
-      fail(e.getMessage());
-    }
-
-    final ComposableFuture<String> f4 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
-    final ComposableFuture<String> f5 = fromError(new RuntimeException("oops"));
-    final ComposableFuture<List<String>> res2 = all(true, Arrays.asList(f4, f5));
-    final long t3 = currentTimeMillis();
-    try {
-      res2.get();
-      fail("should get error.");
-    } catch (InterruptedException | ExecutionException e) {
-      final long t4 = currentTimeMillis();
-      assertTrue((t4 - t3) < 100);
-    }
-
-    final ComposableFuture<String> f6 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
-    final ComposableFuture<String> f7 = fromError(new RuntimeException("oops"));
-    final ComposableFuture<List<String>> res3 = all(true, Arrays.asList(f6, f7));
-    final long t5 = currentTimeMillis();
-    try {
-      res3.get();
-      fail("should get error.");
-    } catch (InterruptedException | ExecutionException e) {
-      final long t6 = currentTimeMillis();
-      System.out.println("time took to fail: " + (t6 - t5));
-      assertTrue((t6 - t5) < 100);
-    }
-
-  }
-
-  @SuppressWarnings("Convert2MethodRef")
-  @Test
-  public void testFuturesToStream() throws InterruptedException {
-    final ComposableFuture<Long> first = schedule(() -> currentTimeMillis(), 1, TimeUnit.SECONDS);
-
-    final ComposableFuture<Long> second = schedule(() -> currentTimeMillis(), 2, TimeUnit.SECONDS);
-
-    final ComposableFuture<Long> third = schedule(() -> currentTimeMillis(), 3, TimeUnit.SECONDS);
-
-    final Iterable<Long> events = toHotObservable(Arrays.asList(first, second, third), true).toBlocking().toIterable();
-    long prevEvent = 0;
-    int counter = 0;
-    for (final Long event : events) {
-      counter++;
-      assertTrue("event should have bigger timestamp than the previous one", event > prevEvent);
-      prevEvent = event;
-    }
-
-    assertEquals("should receive 3 events", counter, 3);
-
-  }
-
-  @Test
-  public void testFutureProviderToStream() {
-    final Observable<Long> stream = toObservable(new FutureProvider<Long>() {
-      private volatile int index = 3;
-      private volatile ComposableFuture<Long> currentRes;
-
-      @SuppressWarnings("Convert2MethodRef")
-      @Override
-      public boolean moveNext() {
-        if (index > 0) {
-          index--;
-          currentRes = schedule(() -> currentTimeMillis(), 100, MILLISECONDS);
-
-          return true;
-        } else {
-          return false;
+        try {
+            final Person result = person.get();
+            assertEquals(result.age, age);
+            assertEquals(result.name, name);
+            assertEquals(result.weight, weight, 0);
+        } catch (InterruptedException | ExecutionException e) {
+            fail(e.getMessage());
         }
-      }
 
-      @Override
-      public ComposableFuture<Long> current() {
-        return currentRes;
-      }
-    });
+        final ComposableFuture<String> first = fromValue("1");
+        final ComposableFuture<Integer> second = fromValue(2);
+        final ComposableFuture<Object> badRes = combine(first, second,
+                (BiFunction<String, Integer, Object>) (left, right) -> {
+                    throw new ExecutionException(new RuntimeException("not the same..."));
+                });
 
-    long current = currentTimeMillis();
-    final Iterable<Long> events = stream.toBlocking().toIterable();
-    int counter = 0;
-    for (final Long event : events) {
-      assertTrue(event > current);
-      current = event;
-      counter++;
+        try {
+            badRes.get();
+            fail("should get an error");
+        } catch (final InterruptedException e) {
+            fail(e.getMessage());
+        } catch (final ExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains("not the same..."));
+        }
+
     }
 
-    assertTrue(counter == 3);
+    @Test
+    public void testCatchingThrowable() throws Exception {
+        final ComposableFuture<Object> failedFuture = fromValue("Success").map(__ -> {
+            throw new OutOfMemoryError();
+        });
 
-  }
+        final AtomicReference<Boolean> failed = new AtomicReference<>(false);
+        final CountDownLatch latch = new CountDownLatch(1);
+        failedFuture.consume(result -> {
+            failed.set(result.isFailure());
+            latch.countDown();
+        });
 
-  @Test
-  public void testFirstNoTimeout() throws Exception {
-    final PassThroughCount passThroughCount = new PassThroughCount(3);
-    try {
-      final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+        latch.await();
 
-      final Map<String, String> res = first(elements, 3).get();
-      assertEquals(3, res.size());
-      assertEquals("one", res.get("one"));
-      assertEquals("two", res.get("two"));
-      assertEquals("three", res.get("three"));
-    } finally {
-      passThroughCount.releaseAllWaiters(); // release last two guys
-    }
-  }
-
-  @Test
-  public void testFirstWithTimeout() throws Exception {
-    final PassThroughCount passThroughCount = new PassThroughCount(2);
-    try {
-      final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
-      passThroughCount.waitForPassers();  // we do not want that the first two elements will not finish due to scheduling issues
-      final Map<String, String> res = first(elements, 3, 10, MILLISECONDS).get();
-
-      assertEquals(2, res.size());
-      assertEquals("one", res.get("one"));
-      assertEquals("two", res.get("two"));
-    } finally {
-      passThroughCount.releaseAllWaiters(); // release last two guys
-    }
-  }
-
-  @Test
-  public void testAllFailOnError() throws Exception {
-    final PassThroughCount passThroughCount = new PassThroughCount(5);
-    final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
-
-    try {
-      all(true, elements).get();
-      fail("should get an exception");
-    } catch (final ExecutionException e) {
-      assertTrue(e.getCause().getMessage().contains("bad element"));
-    } finally {
-      passThroughCount.releaseAllWaiters(); // release last two guys
+        assertTrue("consume should be called, with try of OutOfMemoryError", failed.get());
     }
 
-  }
+    @Test
+    public void testSlowFuture() {
+        final ComposableFuture<String> f1 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
 
-  @Test
-  public void testAllFailFast() throws Exception {
-    final Map<String, ComposableFuture<String>> elements = new HashMap<>();
+        final ComposableFuture<String> f2 = fromValue("fast1");
+        final ComposableFuture<String> f3 = fromValue("fast2");
 
-    elements.put("one", submit(() -> {
-      Thread.sleep(100);
-      return "one";
-    }));
+        final ComposableFuture<List<String>> res = all(Arrays.asList(f1, f2, f3));
+        final long t1 = currentTimeMillis();
+        try {
+            res.get();
+            final long t2 = currentTimeMillis();
+            assertTrue("time is: " + (t2 - t1), (t2 - t1) > 900); // not
+        } catch (InterruptedException | ExecutionException e) {
+            fail(e.getMessage());
+        }
 
-    elements.put("two", submit(() -> {
-      throw new RuntimeException("error...");
-    }));
+        final ComposableFuture<String> f4 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
+        final ComposableFuture<String> f5 = fromError(new RuntimeException("oops"));
+        final ComposableFuture<List<String>> res2 = all(true, Arrays.asList(f4, f5));
+        final long t3 = currentTimeMillis();
+        try {
+            res2.get();
+            fail("should get error.");
+        } catch (InterruptedException | ExecutionException e) {
+            final long t4 = currentTimeMillis();
+            assertTrue((t4 - t3) < 100);
+        }
 
-    final long t1 = currentTimeMillis();
-    try {
-      all(true, elements).get();
-      fail("should fail");
-    } catch (final ExecutionException e) {
-      final long t2 = currentTimeMillis();
-      assertTrue("should fail fast", (t2 - t1) < 50);
-    }
-  }
+        final ComposableFuture<String> f6 = schedule(() -> "slow", 1, TimeUnit.SECONDS);
+        final ComposableFuture<String> f7 = fromError(new RuntimeException("oops"));
+        final ComposableFuture<List<String>> res3 = all(true, Arrays.asList(f6, f7));
+        final long t5 = currentTimeMillis();
+        try {
+            res3.get();
+            fail("should get error.");
+        } catch (InterruptedException | ExecutionException e) {
+            final long t6 = currentTimeMillis();
+            System.out.println("time took to fail: " + (t6 - t5));
+            assertTrue((t6 - t5) < 100);
+        }
 
-  private Map<String, ComposableFuture<String>> createElementsMap(final PassThroughCount passThroughCount) {
-    final Map<String, ComposableFuture<String>> elements = new HashMap<>();
-
-    elements.put("one", submit(() -> {
-      passThroughCount.awaitOrPass(1);
-      return "one";
-    }));
-    elements.put("two", submit(() -> {
-      passThroughCount.awaitOrPass(2);
-      return "two";
-    }));
-    elements.put("three", submit(() -> {
-      passThroughCount.awaitOrPass(3);
-      return "three";
-    }));
-    elements.put("four", submit(() -> {
-      passThroughCount.awaitOrPass(4);
-      throw new RuntimeException("bad element");
-    }));
-    elements.put("five", submit(() -> {
-      passThroughCount.awaitOrPass(5);
-      return "five";
-    }));
-    return elements;
-  }
-
-  @Test
-  public void testWithTimeout() throws Exception {
-    final String RES_STR = "result";
-    final EagerComposableFuture<String> value = new EagerComposableFuture<>();
-
-    final ComposableFuture<String> effectiveValue = value.withTimeout(100, MILLISECONDS);
-    Thread.sleep(50);
-    value.set(RES_STR);
-    assertEquals(RES_STR, value.get());
-    assertEquals(RES_STR, effectiveValue.get());
-
-  }
-
-  @Test(expected = ExecutionException.class)
-  public void testWithTimeoutExpired() throws Exception {
-    final String RES_STR = "result";
-    final EagerComposableFuture<String> value = new EagerComposableFuture<>();
-
-    final ComposableFuture<String> effectiveValue = value.withTimeout(50, MILLISECONDS);
-    Thread.sleep(100);
-    value.set(RES_STR);
-    assertEquals(RES_STR, value.get());
-    effectiveValue.get(); // this should throw an exception
-  }
-
-  private static final class Person {
-    public final int age;
-    public final String name;
-    public final double weight;
-
-
-    private Person(final int age, final String name, final double weight) {
-      this.age = age;
-      this.name = name;
-      this.weight = weight;
-    }
-  }
-
-  class PassThroughCount {
-    final CountDownLatch waitersLatch;
-    final CountDownLatch passersLatch;
-    final int numToPass;
-
-    public PassThroughCount(final int numToPass) {
-      waitersLatch = new CountDownLatch(1);
-      passersLatch = new CountDownLatch(numToPass);
-      this.numToPass = numToPass;
     }
 
-    public void awaitOrPass(final long myOrder) throws InterruptedException {
-      if (myOrder > numToPass) waitersLatch.await();
-      else passersLatch.countDown();
+    @SuppressWarnings("Convert2MethodRef")
+    @Test
+    public void testFuturesToStream() throws InterruptedException {
+        final ComposableFuture<Long> first = schedule(() -> currentTimeMillis(), 1, TimeUnit.SECONDS);
+
+        final ComposableFuture<Long> second = schedule(() -> currentTimeMillis(), 2, TimeUnit.SECONDS);
+
+        final ComposableFuture<Long> third = schedule(() -> currentTimeMillis(), 3, TimeUnit.SECONDS);
+
+        final Iterable<Long> events = toHotObservable(Arrays.asList(first, second, third), true).toBlocking().toIterable();
+        long prevEvent = 0;
+        int counter = 0;
+        for (final Long event : events) {
+            counter++;
+            assertTrue("event should have bigger timestamp than the previous one", event > prevEvent);
+            prevEvent = event;
+        }
+
+        assertEquals("should receive 3 events", counter, 3);
+
     }
 
-    public void releaseAllWaiters() {
-      waitersLatch.countDown();
+    @Test
+    public void testFutureProviderToStream() {
+        final Observable<Long> stream = toObservable(new FutureProvider<Long>() {
+            private volatile int index = 3;
+            private volatile ComposableFuture<Long> currentRes;
+
+            @SuppressWarnings("Convert2MethodRef")
+            @Override
+            public boolean moveNext() {
+                if (index > 0) {
+                    index--;
+                    currentRes = schedule(() -> currentTimeMillis(), 100, MILLISECONDS);
+
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+
+            @Override
+            public ComposableFuture<Long> current() {
+                return currentRes;
+            }
+        });
+
+        long current = currentTimeMillis();
+        final Iterable<Long> events = stream.toBlocking().toIterable();
+        int counter = 0;
+        for (final Long event : events) {
+            assertTrue(event > current);
+            current = event;
+            counter++;
+        }
+
+        assertTrue(counter == 3);
+
     }
 
-    public void waitForPassers() throws InterruptedException {
-      passersLatch.await();
+    @Test
+    public void testFirstNoTimeout() throws Exception {
+        final PassThroughCount passThroughCount = new PassThroughCount(3);
+        try {
+            final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+
+            final Map<String, String> res = first(elements, 3).get();
+            assertEquals(3, res.size());
+            assertEquals("one", res.get("one"));
+            assertEquals("two", res.get("two"));
+            assertEquals("three", res.get("three"));
+        } finally {
+            passThroughCount.releaseAllWaiters(); // release last two guys
+        }
     }
-  }
+
+    @Test
+    public void testFirstWithTimeout() throws Exception {
+        final PassThroughCount passThroughCount = new PassThroughCount(2);
+        try {
+            final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+            passThroughCount.waitForPassers();  // we do not want that the first two elements will not finish due to scheduling issues
+            final Map<String, String> res = first(elements, 3, 10, MILLISECONDS).get();
+
+            assertEquals(2, res.size());
+            assertEquals("one", res.get("one"));
+            assertEquals("two", res.get("two"));
+        } finally {
+            passThroughCount.releaseAllWaiters(); // release last two guys
+        }
+    }
+
+    @Test
+    public void testAllFailOnError() throws Exception {
+        final PassThroughCount passThroughCount = new PassThroughCount(5);
+        final Map<String, ComposableFuture<String>> elements = createElementsMap(passThroughCount);
+
+        try {
+            all(true, elements).get();
+            fail("should get an exception");
+        } catch (final ExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains("bad element"));
+        } finally {
+            passThroughCount.releaseAllWaiters(); // release last two guys
+        }
+
+    }
+
+    @Test
+    public void testAllFailFast() throws Exception {
+        final Map<String, ComposableFuture<String>> elements = new HashMap<>();
+
+        elements.put("one", submit(() -> {
+            Thread.sleep(100);
+            return "one";
+        }));
+
+        elements.put("two", submit(() -> {
+            throw new RuntimeException("error...");
+        }));
+
+        final long t1 = currentTimeMillis();
+        try {
+            all(true, elements).get();
+            fail("should fail");
+        } catch (final ExecutionException e) {
+            final long t2 = currentTimeMillis();
+            assertTrue("should fail fast", (t2 - t1) < 50);
+        }
+    }
+
+    private Map<String, ComposableFuture<String>> createElementsMap(final PassThroughCount passThroughCount) {
+        final Map<String, ComposableFuture<String>> elements = new HashMap<>();
+
+        elements.put("one", submit(() -> {
+            passThroughCount.awaitOrPass(1);
+            return "one";
+        }));
+        elements.put("two", submit(() -> {
+            passThroughCount.awaitOrPass(2);
+            return "two";
+        }));
+        elements.put("three", submit(() -> {
+            passThroughCount.awaitOrPass(3);
+            return "three";
+        }));
+        elements.put("four", submit(() -> {
+            passThroughCount.awaitOrPass(4);
+            throw new RuntimeException("bad element");
+        }));
+        elements.put("five", submit(() -> {
+            passThroughCount.awaitOrPass(5);
+            return "five";
+        }));
+        return elements;
+    }
+
+    @Test
+    public void testTypedErrors() throws Exception {
+        String result = ComposableFutures.<String>submit(() -> {
+            throw new FileNotFoundException("no file...");
+        }).recover(NullPointerException.class, error -> {
+            return "failure";
+        }).recover(FileNotFoundException.class, error -> {
+            return "success";
+        }).recover(error -> {
+            return "failure";
+        }).get();
+
+        Assert.assertEquals("success", result);
+
+        String result2 = ComposableFutures.<String>submit(() -> {
+            throw new FileNotFoundException("no file...");
+        }).recoverWith(NullPointerException.class, error -> {
+            return ComposableFutures.fromValue("failure");
+        }).recoverWith(FileNotFoundException.class, error -> {
+            return ComposableFutures.fromValue("success");
+        }).recoverWith(error -> {
+            return ComposableFutures.fromValue("failure");
+        }).get();
+
+        Assert.assertEquals("success", result2);
+
+    }
+
+    @Test
+    public void testWithTimeout() throws Exception {
+        final String RES_STR = "result";
+        final EagerComposableFuture<String> value = new EagerComposableFuture<>();
+
+        final ComposableFuture<String> effectiveValue = value.withTimeout(100, MILLISECONDS);
+        Thread.sleep(50);
+        value.set(RES_STR);
+        assertEquals(RES_STR, value.get());
+        assertEquals(RES_STR, effectiveValue.get());
+
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testWithTimeoutExpired() throws Exception {
+        final String RES_STR = "result";
+        final EagerComposableFuture<String> value = new EagerComposableFuture<>();
+
+        final ComposableFuture<String> effectiveValue = value.withTimeout(50, MILLISECONDS);
+        Thread.sleep(100);
+        value.set(RES_STR);
+        assertEquals(RES_STR, value.get());
+        effectiveValue.get(); // this should throw an exception
+    }
+
+    private static final class Person {
+        public final int age;
+        public final String name;
+        public final double weight;
+
+
+        private Person(final int age, final String name, final double weight) {
+            this.age = age;
+            this.name = name;
+            this.weight = weight;
+        }
+    }
+
+    class PassThroughCount {
+        final CountDownLatch waitersLatch;
+        final CountDownLatch passersLatch;
+        final int numToPass;
+
+        public PassThroughCount(final int numToPass) {
+            waitersLatch = new CountDownLatch(1);
+            passersLatch = new CountDownLatch(numToPass);
+            this.numToPass = numToPass;
+        }
+
+        public void awaitOrPass(final long myOrder) throws InterruptedException {
+            if (myOrder > numToPass) waitersLatch.await();
+            else passersLatch.countDown();
+        }
+
+        public void releaseAllWaiters() {
+            waitersLatch.countDown();
+        }
+
+        public void waitForPassers() throws InterruptedException {
+            passersLatch.await();
+        }
+    }
 
 }

--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/LazyComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/LazyComposableFutureTest.java
@@ -7,6 +7,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import rx.Observable;
 
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -19,269 +20,299 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class LazyComposableFutureTest {
 
-  @Test
-  public void testFromValue() throws ExecutionException, InterruptedException {
-    final ComposableFuture<Integer> res = LazyComposableFuture.fromValue(3);
-    final Integer result = res.get();
-    Assert.assertEquals(result, new Integer(3));
-  }
-
-  @Test
-  public void testFromError() throws InterruptedException {
-    final String errorMessage = "oh no...";
-    final LazyComposableFuture<Object> res = LazyComposableFuture.fromError(new RuntimeException(errorMessage));
-
-    res.consume(result -> System.out.println("got: " + result));
-
-    try {
-      res.get();
-      Assert.fail("should get an exception");
-    } catch (final ExecutionException e) {
-      final Throwable cause = e.getCause();
-      Assert.assertTrue(cause != null);
-      Assert.assertTrue(cause.getClass() == RuntimeException.class);
-      Assert.assertTrue(cause.getMessage().equals(errorMessage));
-    }
-  }
-
-  @Test
-  public void testBuildFuture() throws ExecutionException, InterruptedException {
-    final AtomicInteger producerCounter = new AtomicInteger();
-    final String message = "great success";
-    final ComposableFuture<String> res = LazyComposableFuture.build(consumer -> {
-      producerCounter.incrementAndGet();
-      consumer.consume(Try.fromValue(message));
-    });
-
-    Thread.sleep(100);
-    Assert.assertEquals(producerCounter.get(), 0);
-
-    res.consume(result -> System.out.println("got: " + result));
-
-    final String result = res.get();
-    Assert.assertTrue(result.equals(message));
-    Assert.assertEquals(producerCounter.get(), 2);
-  }
-
-  @Test
-  public void testContinueOnSuccess() throws ExecutionException, InterruptedException {
-    final ComposableFuture<String> res = LazyComposableFuture.fromValue("one").
-      map(result -> result + ",two").
-      flatMap(result -> ComposableFutures.fromValue(result + ",three"));
-
-    res.consume(result -> System.out.println("get: " + result));
-
-    final String result = res.get();
-    Assert.assertEquals(result, "one,two,three");
-  }
-
-  @Test
-  public void testContinueOnFailure() throws ExecutionException, InterruptedException {
-    final ComposableFuture<String> res1 = LazyComposableFuture.fromValue("one").recover(error -> "two");
-
-    Assert.assertEquals(res1.get(), "one");
-
-    final ComposableFuture<String> res2 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
-      recover(error -> "ok");
-
-    Assert.assertEquals(res2.get(), "ok");
-
-    final ComposableFuture<String> res3 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
-      recoverWith(error -> LazyComposableFuture.fromError(new RuntimeException("even worse")));
-
-    try {
-      res3.get();
-      Assert.fail("should fail");
-    } catch (final ExecutionException e) {
-      final Throwable cause = e.getCause();
-      Assert.assertTrue(cause != null);
-      Assert.assertEquals(cause.getClass(), RuntimeException.class);
-      Assert.assertEquals(cause.getMessage(), "even worse");
-    }
-  }
-
-  @Test
-  public void testSubmit() throws ExecutionException, InterruptedException {
-    final AtomicInteger prodCounter = new AtomicInteger();
-    final ExecutorService executor = Executors.newFixedThreadPool(1);
-    final ComposableFuture<String> res = LazyComposableFuture.submit(executor, () -> {
-      prodCounter.incrementAndGet();
-      return "first";
-    }, false).flatMap(result -> LazyComposableFuture.submit(executor, () -> {
-      prodCounter.incrementAndGet();
-      return result + ",second";
-    }, false));
-
-    res.consume(result -> System.out.println("got: " + result));
-
-    final String result = res.get();
-    Assert.assertEquals(result, "first,second");
-    Assert.assertEquals(prodCounter.get(), 4);
-    executor.shutdown();
-  }
-
-  @Test
-  public void testSchedule() throws ExecutionException, InterruptedException {
-    final Scheduler scheduler = new ThreadPoolBasedScheduler(1,"test-schedule");
-    final ComposableFuture<Integer> res1 = LazyComposableFuture.schedule(scheduler, () -> 1, 100, TimeUnit.MILLISECONDS);
-
-    final ComposableFuture<Integer> res2 = LazyComposableFuture.schedule(scheduler, () -> 2, 300, TimeUnit.MILLISECONDS);
-
-    final ComposableFuture<Integer> res3 = LazyComposableFuture.schedule(scheduler, () -> 3, 200, TimeUnit.MILLISECONDS);
-
-    final ComposableFuture<List<Integer>> res = LazyComposableFuture.collectAll(Arrays.asList(res1, res2, res3));
-
-    final List<Integer> result = res.get();
-    Assert.assertEquals(result.size(), 3);
-    Assert.assertEquals(result.get(0), new Integer(1));
-    Assert.assertEquals(result.get(1), new Integer(2));
-    Assert.assertEquals(result.get(2), new Integer(3));
-
-  }
-
-  @Test
-  public void testWithTimeout() throws ExecutionException, InterruptedException {
-    final Scheduler scheduler = new ThreadPoolBasedScheduler(1,"test-with-timeout");
-    final LazyComposableFuture<String> fast = LazyComposableFuture.schedule(scheduler, () -> "fast", 100, TimeUnit.MILLISECONDS).withTimeout(scheduler, 200, TimeUnit.MILLISECONDS);
-
-    final String res1 = fast.get();
-    Assert.assertEquals(res1, "fast");
-
-    final LazyComposableFuture<String> slow = LazyComposableFuture.schedule(scheduler, () -> "slow", 200, TimeUnit.MILLISECONDS).withTimeout(scheduler, 100, TimeUnit.MILLISECONDS);
-
-    try {
-      slow.get();
-      Assert.fail("should have timed out");
-    } catch (final ExecutionException e) {
-      final Throwable cause = e.getCause();
-      Assert.assertEquals(cause.getClass(), TimeoutException.class);
+    @Test
+    public void testFromValue() throws ExecutionException, InterruptedException {
+        final ComposableFuture<Integer> res = LazyComposableFuture.fromValue(3);
+        final Integer result = res.get();
+        Assert.assertEquals(result, new Integer(3));
     }
 
-    scheduler.shutdown();
-  }
+    @Test
+    public void testFromError() throws InterruptedException {
+        final String errorMessage = "oh no...";
+        final LazyComposableFuture<Object> res = LazyComposableFuture.fromError(new RuntimeException(errorMessage));
 
-  @Test
-  public void testDoubleDispatch() throws ExecutionException, InterruptedException {
-    final ExecutorService executor = Executors.newFixedThreadPool(2);
-    final Scheduler scheduler = new ThreadPoolBasedScheduler(1,"test-double-dispatch");
+        res.consume(result -> System.out.println("got: " + result));
 
-    final AtomicBoolean state1 = new AtomicBoolean(false);
-    final LazyComposableFuture<String> res1 = LazyComposableFuture.submit(executor, () -> {
-      if (state1.compareAndSet(false, true)) {
-        Thread.sleep(200);
-        return "first";
-      } else {
-        Thread.sleep(50);
-        return "second";
-      }
-    }, false).doubleDispatch(scheduler, 100, TimeUnit.MILLISECONDS);
+        try {
+            res.get();
+            Assert.fail("should get an exception");
+        } catch (final ExecutionException e) {
+            final Throwable cause = e.getCause();
+            Assert.assertTrue(cause != null);
+            Assert.assertTrue(cause.getClass() == RuntimeException.class);
+            Assert.assertTrue(cause.getMessage().equals(errorMessage));
+        }
+    }
 
-    final long t1 = System.currentTimeMillis();
-    final String result1 = res1.get();
-    final long t2 = System.currentTimeMillis();
+    @Test
+    public void testBuildFuture() throws ExecutionException, InterruptedException {
+        final AtomicInteger producerCounter = new AtomicInteger();
+        final String message = "great success";
+        final ComposableFuture<String> res = LazyComposableFuture.build(consumer -> {
+            producerCounter.incrementAndGet();
+            consumer.consume(Try.fromValue(message));
+        });
 
-    Assert.assertEquals(result1, "second");
-    Assert.assertTrue((t2 - t1) < 200);
-
-    final AtomicBoolean state2 = new AtomicBoolean(false);
-    final LazyComposableFuture<String> res2 = LazyComposableFuture.submit(executor, () -> {
-      if (state2.compareAndSet(false, true)) {
         Thread.sleep(100);
-        return "first";
-      } else {
-        Thread.sleep(50);
-        return "second";
-      }
-    }, false).doubleDispatch(scheduler, 150, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(producerCounter.get(), 0);
 
-    final long t3 = System.currentTimeMillis();
-    final String result2 = res2.get();
-    final long t4 = System.currentTimeMillis();
+        res.consume(result -> System.out.println("got: " + result));
 
-    Assert.assertEquals(result2, "first");
-    Assert.assertTrue((t4 - t3) < 150);
-
-    final AtomicBoolean state3 = new AtomicBoolean(false);
-    final LazyComposableFuture<String> res3 = LazyComposableFuture.submit(executor, () -> {
-      if (state3.compareAndSet(false, true)) {
-        Thread.sleep(100);
-        return "first";
-      } else {
-        Thread.sleep(200);
-        return "second";
-      }
-    }, false).doubleDispatch(scheduler, 50, TimeUnit.MILLISECONDS);
-
-    final long t5 = System.currentTimeMillis();
-    final String result3 = res3.get();
-    final long t6 = System.currentTimeMillis();
-
-    Assert.assertEquals(result3, "first");
-    Assert.assertTrue((t6 - t5) < 200);
-
-    executor.shutdown();
-    scheduler.shutdown();
-  }
-
-  @Test
-  public void testColdStream() {
-    final Scheduler scheduler = new ThreadPoolBasedScheduler(1,"test-cold-stream");
-    final ComposableFuture<String> first = LazyComposableFuture.schedule(scheduler, () -> "first", 100, TimeUnit.MILLISECONDS);
-
-    final ComposableFuture<String> second = LazyComposableFuture.schedule(scheduler, () -> "second", 200, TimeUnit.MILLISECONDS);
-
-    final ComposableFuture<String> third = LazyComposableFuture.schedule(scheduler, () -> "third", 300, TimeUnit.MILLISECONDS);
-
-    final Observable<String> stream = ComposableFutures.toColdObservable(Arrays.asList(first, second, third));
-
-    for (int i = 0; i < 10; i++) {
-      final Iterable<String> results = stream.toBlocking().toIterable();
-      final List<String> resultsList = new ArrayList<>();
-      for (final String result : results) {
-        resultsList.add(result);
-      }
-
-      Assert.assertEquals(resultsList.size(), 3);
-      Assert.assertEquals(resultsList.get(0), "first");
-      Assert.assertEquals(resultsList.get(1), "second");
-      Assert.assertEquals(resultsList.get(2), "third");
+        final String result = res.get();
+        Assert.assertTrue(result.equals(message));
+        Assert.assertEquals(producerCounter.get(), 2);
     }
 
-    scheduler.shutdown();
-  }
+    @Test
+    public void testContinueOnSuccess() throws ExecutionException, InterruptedException {
+        final ComposableFuture<String> res = LazyComposableFuture.fromValue("one").
+                map(result -> result + ",two").
+                flatMap(result -> ComposableFutures.fromValue(result + ",three"));
 
-  @Test
-  public void testColdRecursiveStream() {
+        res.consume(result -> System.out.println("get: " + result));
 
-    final AtomicInteger counter = new AtomicInteger(0);
-    final int repeats = 5;
+        final String result = res.get();
+        Assert.assertEquals(result, "one,two,three");
+    }
 
-    final ComposableFuture<String> lazyString = LazyComposableFuture.apply(() -> {
-      counter.incrementAndGet();
-      return "stateless lazy evaluated";
-    });
+    @Test
+    public void testContinueOnFailure() throws ExecutionException, InterruptedException {
+        final ComposableFuture<String> res1 = LazyComposableFuture.fromValue("one").recover(error -> "two");
 
-    final Observable<String> stringObservable = ComposableFutures.toColdObservable(new RecursiveFutureProvider<String>() {
-      @Override
-      public ComposableFuture<String> provide() {
-        return lazyString;
-      }
+        Assert.assertEquals(res1.get(), "one");
 
-      @Override
-      public Predicate<String> createStopCriteria() {
-        return new Predicate<String>() {
-          private volatile int i;
-          @Override
-          public boolean apply(final String s) {
-            return ++i >= repeats;
-          }
-        };
-      }
-    });
+        final ComposableFuture<String> res2 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
+                recover(error -> "ok");
 
-    stringObservable.toBlocking().first();
-    stringObservable.toBlocking().first();
+        Assert.assertEquals(res2.get(), "ok");
 
-    Assert.assertTrue("counter of evaluations should be 10", counter.get() == repeats * 2);
-  }
+        final ComposableFuture<String> res3 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
+                recoverWith(error -> LazyComposableFuture.fromError(new RuntimeException("even worse")));
+
+        try {
+            res3.get();
+            Assert.fail("should fail");
+        } catch (final ExecutionException e) {
+            final Throwable cause = e.getCause();
+            Assert.assertTrue(cause != null);
+            Assert.assertEquals(cause.getClass(), RuntimeException.class);
+            Assert.assertEquals(cause.getMessage(), "even worse");
+        }
+    }
+
+    @Test
+    public void testSubmit() throws ExecutionException, InterruptedException {
+        final AtomicInteger prodCounter = new AtomicInteger();
+        final ExecutorService executor = Executors.newFixedThreadPool(1);
+        final ComposableFuture<String> res = LazyComposableFuture.submit(executor, () -> {
+            prodCounter.incrementAndGet();
+            return "first";
+        }, false).flatMap(result -> LazyComposableFuture.submit(executor, () -> {
+            prodCounter.incrementAndGet();
+            return result + ",second";
+        }, false));
+
+        res.consume(result -> System.out.println("got: " + result));
+
+        final String result = res.get();
+        Assert.assertEquals(result, "first,second");
+        Assert.assertEquals(prodCounter.get(), 4);
+        executor.shutdown();
+    }
+
+    @Test
+    public void testSchedule() throws ExecutionException, InterruptedException {
+        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-schedule");
+        final ComposableFuture<Integer> res1 = LazyComposableFuture.schedule(scheduler, () -> 1, 100, TimeUnit.MILLISECONDS);
+
+        final ComposableFuture<Integer> res2 = LazyComposableFuture.schedule(scheduler, () -> 2, 300, TimeUnit.MILLISECONDS);
+
+        final ComposableFuture<Integer> res3 = LazyComposableFuture.schedule(scheduler, () -> 3, 200, TimeUnit.MILLISECONDS);
+
+        final ComposableFuture<List<Integer>> res = LazyComposableFuture.collectAll(Arrays.asList(res1, res2, res3));
+
+        final List<Integer> result = res.get();
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.get(0), new Integer(1));
+        Assert.assertEquals(result.get(1), new Integer(2));
+        Assert.assertEquals(result.get(2), new Integer(3));
+
+    }
+
+    @Test
+    public void testWithTimeout() throws ExecutionException, InterruptedException {
+        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-with-timeout");
+        final LazyComposableFuture<String> fast = LazyComposableFuture.schedule(scheduler, () -> "fast", 100, TimeUnit.MILLISECONDS).withTimeout(scheduler, 200, TimeUnit.MILLISECONDS);
+
+        final String res1 = fast.get();
+        Assert.assertEquals(res1, "fast");
+
+        final LazyComposableFuture<String> slow = LazyComposableFuture.schedule(scheduler, () -> "slow", 200, TimeUnit.MILLISECONDS).withTimeout(scheduler, 100, TimeUnit.MILLISECONDS);
+
+        try {
+            slow.get();
+            Assert.fail("should have timed out");
+        } catch (final ExecutionException e) {
+            final Throwable cause = e.getCause();
+            Assert.assertEquals(cause.getClass(), TimeoutException.class);
+        }
+
+        scheduler.shutdown();
+    }
+
+    @Test
+    public void testDoubleDispatch() throws ExecutionException, InterruptedException {
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-double-dispatch");
+
+        final AtomicBoolean state1 = new AtomicBoolean(false);
+        final LazyComposableFuture<String> res1 = LazyComposableFuture.submit(executor, () -> {
+            if (state1.compareAndSet(false, true)) {
+                Thread.sleep(200);
+                return "first";
+            } else {
+                Thread.sleep(50);
+                return "second";
+            }
+        }, false).doubleDispatch(scheduler, 100, TimeUnit.MILLISECONDS);
+
+        final long t1 = System.currentTimeMillis();
+        final String result1 = res1.get();
+        final long t2 = System.currentTimeMillis();
+
+        Assert.assertEquals(result1, "second");
+        Assert.assertTrue((t2 - t1) < 200);
+
+        final AtomicBoolean state2 = new AtomicBoolean(false);
+        final LazyComposableFuture<String> res2 = LazyComposableFuture.submit(executor, () -> {
+            if (state2.compareAndSet(false, true)) {
+                Thread.sleep(100);
+                return "first";
+            } else {
+                Thread.sleep(50);
+                return "second";
+            }
+        }, false).doubleDispatch(scheduler, 150, TimeUnit.MILLISECONDS);
+
+        final long t3 = System.currentTimeMillis();
+        final String result2 = res2.get();
+        final long t4 = System.currentTimeMillis();
+
+        Assert.assertEquals(result2, "first");
+        Assert.assertTrue((t4 - t3) < 150);
+
+        final AtomicBoolean state3 = new AtomicBoolean(false);
+        final LazyComposableFuture<String> res3 = LazyComposableFuture.submit(executor, () -> {
+            if (state3.compareAndSet(false, true)) {
+                Thread.sleep(100);
+                return "first";
+            } else {
+                Thread.sleep(200);
+                return "second";
+            }
+        }, false).doubleDispatch(scheduler, 50, TimeUnit.MILLISECONDS);
+
+        final long t5 = System.currentTimeMillis();
+        final String result3 = res3.get();
+        final long t6 = System.currentTimeMillis();
+
+        Assert.assertEquals(result3, "first");
+        Assert.assertTrue((t6 - t5) < 200);
+
+        executor.shutdown();
+        scheduler.shutdown();
+    }
+
+    @Test
+    public void testColdStream() {
+        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-cold-stream");
+        final ComposableFuture<String> first = LazyComposableFuture.schedule(scheduler, () -> "first", 100, TimeUnit.MILLISECONDS);
+
+        final ComposableFuture<String> second = LazyComposableFuture.schedule(scheduler, () -> "second", 200, TimeUnit.MILLISECONDS);
+
+        final ComposableFuture<String> third = LazyComposableFuture.schedule(scheduler, () -> "third", 300, TimeUnit.MILLISECONDS);
+
+        final Observable<String> stream = ComposableFutures.toColdObservable(Arrays.asList(first, second, third));
+
+        for (int i = 0; i < 10; i++) {
+            final Iterable<String> results = stream.toBlocking().toIterable();
+            final List<String> resultsList = new ArrayList<>();
+            for (final String result : results) {
+                resultsList.add(result);
+            }
+
+            Assert.assertEquals(resultsList.size(), 3);
+            Assert.assertEquals(resultsList.get(0), "first");
+            Assert.assertEquals(resultsList.get(1), "second");
+            Assert.assertEquals(resultsList.get(2), "third");
+        }
+
+        scheduler.shutdown();
+    }
+
+    @Test
+    public void testTypedErrors() throws Exception {
+        String result = ComposableFutures.<String>submitLazy(false, () -> {
+            throw new FileNotFoundException("no file...");
+        }).recover(NullPointerException.class, error -> {
+            return "failure";
+        }).recover(FileNotFoundException.class, error -> {
+            return "success";
+        }).recover(error -> {
+            return "failure";
+        }).get();
+
+        Assert.assertEquals("success", result);
+
+        String result2 = ComposableFutures.<String>submitLazy(false, () -> {
+            throw new FileNotFoundException("no file...");
+        }).recoverWith(NullPointerException.class, error -> {
+            return ComposableFutures.fromValue("failure");
+        }).recoverWith(FileNotFoundException.class, error -> {
+            return ComposableFutures.fromValue("success");
+        }).recoverWith(error -> {
+            return ComposableFutures.fromValue("failure");
+        }).get();
+
+        Assert.assertEquals("success", result2);
+
+    }
+
+
+    @Test
+    public void testColdRecursiveStream() {
+
+        final AtomicInteger counter = new AtomicInteger(0);
+        final int repeats = 5;
+
+        final ComposableFuture<String> lazyString = LazyComposableFuture.apply(() -> {
+            counter.incrementAndGet();
+            return "stateless lazy evaluated";
+        });
+
+        final Observable<String> stringObservable = ComposableFutures.toColdObservable(new RecursiveFutureProvider<String>() {
+            @Override
+            public ComposableFuture<String> provide() {
+                return lazyString;
+            }
+
+            @Override
+            public Predicate<String> createStopCriteria() {
+                return new Predicate<String>() {
+                    private volatile int i;
+
+                    @Override
+                    public boolean apply(final String s) {
+                        return ++i >= repeats;
+                    }
+                };
+            }
+        });
+
+        stringObservable.toBlocking().first();
+        stringObservable.toBlocking().first();
+
+        Assert.assertTrue("counter of evaluations should be 10", counter.get() == repeats * 2);
+    }
 }

--- a/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/LazyComposableFutureTest.java
+++ b/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/LazyComposableFutureTest.java
@@ -20,299 +20,299 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class LazyComposableFutureTest {
 
-    @Test
-    public void testFromValue() throws ExecutionException, InterruptedException {
-        final ComposableFuture<Integer> res = LazyComposableFuture.fromValue(3);
-        final Integer result = res.get();
-        Assert.assertEquals(result, new Integer(3));
+  @Test
+  public void testFromValue() throws ExecutionException, InterruptedException {
+    final ComposableFuture<Integer> res = LazyComposableFuture.fromValue(3);
+    final Integer result = res.get();
+    Assert.assertEquals(result, new Integer(3));
+  }
+
+  @Test
+  public void testFromError() throws InterruptedException {
+    final String errorMessage = "oh no...";
+    final LazyComposableFuture<Object> res = LazyComposableFuture.fromError(new RuntimeException(errorMessage));
+
+    res.consume(result -> System.out.println("got: " + result));
+
+    try {
+      res.get();
+      Assert.fail("should get an exception");
+    } catch (final ExecutionException e) {
+      final Throwable cause = e.getCause();
+      Assert.assertTrue(cause != null);
+      Assert.assertTrue(cause.getClass() == RuntimeException.class);
+      Assert.assertTrue(cause.getMessage().equals(errorMessage));
+    }
+  }
+
+  @Test
+  public void testBuildFuture() throws ExecutionException, InterruptedException {
+    final AtomicInteger producerCounter = new AtomicInteger();
+    final String message = "great success";
+    final ComposableFuture<String> res = LazyComposableFuture.build(consumer -> {
+      producerCounter.incrementAndGet();
+      consumer.consume(Try.fromValue(message));
+    });
+
+    Thread.sleep(100);
+    Assert.assertEquals(producerCounter.get(), 0);
+
+    res.consume(result -> System.out.println("got: " + result));
+
+    final String result = res.get();
+    Assert.assertTrue(result.equals(message));
+    Assert.assertEquals(producerCounter.get(), 2);
+  }
+
+  @Test
+  public void testContinueOnSuccess() throws ExecutionException, InterruptedException {
+    final ComposableFuture<String> res = LazyComposableFuture.fromValue("one").
+        map(result -> result + ",two").
+        flatMap(result -> ComposableFutures.fromValue(result + ",three"));
+
+    res.consume(result -> System.out.println("get: " + result));
+
+    final String result = res.get();
+    Assert.assertEquals(result, "one,two,three");
+  }
+
+  @Test
+  public void testContinueOnFailure() throws ExecutionException, InterruptedException {
+    final ComposableFuture<String> res1 = LazyComposableFuture.fromValue("one").recover(error -> "two");
+
+    Assert.assertEquals(res1.get(), "one");
+
+    final ComposableFuture<String> res2 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
+        recover(error -> "ok");
+
+    Assert.assertEquals(res2.get(), "ok");
+
+    final ComposableFuture<String> res3 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
+        recoverWith(error -> LazyComposableFuture.fromError(new RuntimeException("even worse")));
+
+    try {
+      res3.get();
+      Assert.fail("should fail");
+    } catch (final ExecutionException e) {
+      final Throwable cause = e.getCause();
+      Assert.assertTrue(cause != null);
+      Assert.assertEquals(cause.getClass(), RuntimeException.class);
+      Assert.assertEquals(cause.getMessage(), "even worse");
+    }
+  }
+
+  @Test
+  public void testSubmit() throws ExecutionException, InterruptedException {
+    final AtomicInteger prodCounter = new AtomicInteger();
+    final ExecutorService executor = Executors.newFixedThreadPool(1);
+    final ComposableFuture<String> res = LazyComposableFuture.submit(executor, () -> {
+      prodCounter.incrementAndGet();
+      return "first";
+    }, false).flatMap(result -> LazyComposableFuture.submit(executor, () -> {
+      prodCounter.incrementAndGet();
+      return result + ",second";
+    }, false));
+
+    res.consume(result -> System.out.println("got: " + result));
+
+    final String result = res.get();
+    Assert.assertEquals(result, "first,second");
+    Assert.assertEquals(prodCounter.get(), 4);
+    executor.shutdown();
+  }
+
+  @Test
+  public void testSchedule() throws ExecutionException, InterruptedException {
+    final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-schedule");
+    final ComposableFuture<Integer> res1 = LazyComposableFuture.schedule(scheduler, () -> 1, 100, TimeUnit.MILLISECONDS);
+
+    final ComposableFuture<Integer> res2 = LazyComposableFuture.schedule(scheduler, () -> 2, 300, TimeUnit.MILLISECONDS);
+
+    final ComposableFuture<Integer> res3 = LazyComposableFuture.schedule(scheduler, () -> 3, 200, TimeUnit.MILLISECONDS);
+
+    final ComposableFuture<List<Integer>> res = LazyComposableFuture.collectAll(Arrays.asList(res1, res2, res3));
+
+    final List<Integer> result = res.get();
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals(result.get(0), new Integer(1));
+    Assert.assertEquals(result.get(1), new Integer(2));
+    Assert.assertEquals(result.get(2), new Integer(3));
+
+  }
+
+  @Test
+  public void testWithTimeout() throws ExecutionException, InterruptedException {
+    final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-with-timeout");
+    final LazyComposableFuture<String> fast = LazyComposableFuture.schedule(scheduler, () -> "fast", 100, TimeUnit.MILLISECONDS).withTimeout(scheduler, 200, TimeUnit.MILLISECONDS);
+
+    final String res1 = fast.get();
+    Assert.assertEquals(res1, "fast");
+
+    final LazyComposableFuture<String> slow = LazyComposableFuture.schedule(scheduler, () -> "slow", 200, TimeUnit.MILLISECONDS).withTimeout(scheduler, 100, TimeUnit.MILLISECONDS);
+
+    try {
+      slow.get();
+      Assert.fail("should have timed out");
+    } catch (final ExecutionException e) {
+      final Throwable cause = e.getCause();
+      Assert.assertEquals(cause.getClass(), TimeoutException.class);
     }
 
-    @Test
-    public void testFromError() throws InterruptedException {
-        final String errorMessage = "oh no...";
-        final LazyComposableFuture<Object> res = LazyComposableFuture.fromError(new RuntimeException(errorMessage));
+    scheduler.shutdown();
+  }
 
-        res.consume(result -> System.out.println("got: " + result));
+  @Test
+  public void testDoubleDispatch() throws ExecutionException, InterruptedException {
+    final ExecutorService executor = Executors.newFixedThreadPool(2);
+    final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-double-dispatch");
 
-        try {
-            res.get();
-            Assert.fail("should get an exception");
-        } catch (final ExecutionException e) {
-            final Throwable cause = e.getCause();
-            Assert.assertTrue(cause != null);
-            Assert.assertTrue(cause.getClass() == RuntimeException.class);
-            Assert.assertTrue(cause.getMessage().equals(errorMessage));
-        }
-    }
+    final AtomicBoolean state1 = new AtomicBoolean(false);
+    final LazyComposableFuture<String> res1 = LazyComposableFuture.submit(executor, () -> {
+      if (state1.compareAndSet(false, true)) {
+        Thread.sleep(200);
+        return "first";
+      } else {
+        Thread.sleep(50);
+        return "second";
+      }
+    }, false).doubleDispatch(scheduler, 100, TimeUnit.MILLISECONDS);
 
-    @Test
-    public void testBuildFuture() throws ExecutionException, InterruptedException {
-        final AtomicInteger producerCounter = new AtomicInteger();
-        final String message = "great success";
-        final ComposableFuture<String> res = LazyComposableFuture.build(consumer -> {
-            producerCounter.incrementAndGet();
-            consumer.consume(Try.fromValue(message));
-        });
+    final long t1 = System.currentTimeMillis();
+    final String result1 = res1.get();
+    final long t2 = System.currentTimeMillis();
 
+    Assert.assertEquals(result1, "second");
+    Assert.assertTrue((t2 - t1) < 200);
+
+    final AtomicBoolean state2 = new AtomicBoolean(false);
+    final LazyComposableFuture<String> res2 = LazyComposableFuture.submit(executor, () -> {
+      if (state2.compareAndSet(false, true)) {
         Thread.sleep(100);
-        Assert.assertEquals(producerCounter.get(), 0);
+        return "first";
+      } else {
+        Thread.sleep(50);
+        return "second";
+      }
+    }, false).doubleDispatch(scheduler, 150, TimeUnit.MILLISECONDS);
 
-        res.consume(result -> System.out.println("got: " + result));
+    final long t3 = System.currentTimeMillis();
+    final String result2 = res2.get();
+    final long t4 = System.currentTimeMillis();
 
-        final String result = res.get();
-        Assert.assertTrue(result.equals(message));
-        Assert.assertEquals(producerCounter.get(), 2);
+    Assert.assertEquals(result2, "first");
+    Assert.assertTrue((t4 - t3) < 150);
+
+    final AtomicBoolean state3 = new AtomicBoolean(false);
+    final LazyComposableFuture<String> res3 = LazyComposableFuture.submit(executor, () -> {
+      if (state3.compareAndSet(false, true)) {
+        Thread.sleep(100);
+        return "first";
+      } else {
+        Thread.sleep(200);
+        return "second";
+      }
+    }, false).doubleDispatch(scheduler, 50, TimeUnit.MILLISECONDS);
+
+    final long t5 = System.currentTimeMillis();
+    final String result3 = res3.get();
+    final long t6 = System.currentTimeMillis();
+
+    Assert.assertEquals(result3, "first");
+    Assert.assertTrue((t6 - t5) < 200);
+
+    executor.shutdown();
+    scheduler.shutdown();
+  }
+
+  @Test
+  public void testColdStream() {
+    final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-cold-stream");
+    final ComposableFuture<String> first = LazyComposableFuture.schedule(scheduler, () -> "first", 100, TimeUnit.MILLISECONDS);
+
+    final ComposableFuture<String> second = LazyComposableFuture.schedule(scheduler, () -> "second", 200, TimeUnit.MILLISECONDS);
+
+    final ComposableFuture<String> third = LazyComposableFuture.schedule(scheduler, () -> "third", 300, TimeUnit.MILLISECONDS);
+
+    final Observable<String> stream = ComposableFutures.toColdObservable(Arrays.asList(first, second, third));
+
+    for (int i = 0; i < 10; i++) {
+      final Iterable<String> results = stream.toBlocking().toIterable();
+      final List<String> resultsList = new ArrayList<>();
+      for (final String result : results) {
+        resultsList.add(result);
+      }
+
+      Assert.assertEquals(resultsList.size(), 3);
+      Assert.assertEquals(resultsList.get(0), "first");
+      Assert.assertEquals(resultsList.get(1), "second");
+      Assert.assertEquals(resultsList.get(2), "third");
     }
 
-    @Test
-    public void testContinueOnSuccess() throws ExecutionException, InterruptedException {
-        final ComposableFuture<String> res = LazyComposableFuture.fromValue("one").
-                map(result -> result + ",two").
-                flatMap(result -> ComposableFutures.fromValue(result + ",three"));
+    scheduler.shutdown();
+  }
 
-        res.consume(result -> System.out.println("get: " + result));
+  @Test
+  public void testTypedErrors() throws Exception {
+    String result = ComposableFutures.<String>submitLazy(false, () -> {
+      throw new FileNotFoundException("no file...");
+    }).recover(NullPointerException.class, error -> {
+      return "failure";
+    }).recover(FileNotFoundException.class, error -> {
+      return "success";
+    }).recover(error -> {
+      return "failure";
+    }).get();
 
-        final String result = res.get();
-        Assert.assertEquals(result, "one,two,three");
-    }
+    Assert.assertEquals("success", result);
 
-    @Test
-    public void testContinueOnFailure() throws ExecutionException, InterruptedException {
-        final ComposableFuture<String> res1 = LazyComposableFuture.fromValue("one").recover(error -> "two");
+    String result2 = ComposableFutures.<String>submitLazy(false, () -> {
+      throw new FileNotFoundException("no file...");
+    }).recoverWith(NullPointerException.class, error -> {
+      return ComposableFutures.fromValue("failure");
+    }).recoverWith(FileNotFoundException.class, error -> {
+      return ComposableFutures.fromValue("success");
+    }).recoverWith(error -> {
+      return ComposableFutures.fromValue("failure");
+    }).get();
 
-        Assert.assertEquals(res1.get(), "one");
+    Assert.assertEquals("success", result2);
 
-        final ComposableFuture<String> res2 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
-                recover(error -> "ok");
-
-        Assert.assertEquals(res2.get(), "ok");
-
-        final ComposableFuture<String> res3 = LazyComposableFuture.<String>fromError(new RuntimeException("bad start")).
-                recoverWith(error -> LazyComposableFuture.fromError(new RuntimeException("even worse")));
-
-        try {
-            res3.get();
-            Assert.fail("should fail");
-        } catch (final ExecutionException e) {
-            final Throwable cause = e.getCause();
-            Assert.assertTrue(cause != null);
-            Assert.assertEquals(cause.getClass(), RuntimeException.class);
-            Assert.assertEquals(cause.getMessage(), "even worse");
-        }
-    }
-
-    @Test
-    public void testSubmit() throws ExecutionException, InterruptedException {
-        final AtomicInteger prodCounter = new AtomicInteger();
-        final ExecutorService executor = Executors.newFixedThreadPool(1);
-        final ComposableFuture<String> res = LazyComposableFuture.submit(executor, () -> {
-            prodCounter.incrementAndGet();
-            return "first";
-        }, false).flatMap(result -> LazyComposableFuture.submit(executor, () -> {
-            prodCounter.incrementAndGet();
-            return result + ",second";
-        }, false));
-
-        res.consume(result -> System.out.println("got: " + result));
-
-        final String result = res.get();
-        Assert.assertEquals(result, "first,second");
-        Assert.assertEquals(prodCounter.get(), 4);
-        executor.shutdown();
-    }
-
-    @Test
-    public void testSchedule() throws ExecutionException, InterruptedException {
-        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-schedule");
-        final ComposableFuture<Integer> res1 = LazyComposableFuture.schedule(scheduler, () -> 1, 100, TimeUnit.MILLISECONDS);
-
-        final ComposableFuture<Integer> res2 = LazyComposableFuture.schedule(scheduler, () -> 2, 300, TimeUnit.MILLISECONDS);
-
-        final ComposableFuture<Integer> res3 = LazyComposableFuture.schedule(scheduler, () -> 3, 200, TimeUnit.MILLISECONDS);
-
-        final ComposableFuture<List<Integer>> res = LazyComposableFuture.collectAll(Arrays.asList(res1, res2, res3));
-
-        final List<Integer> result = res.get();
-        Assert.assertEquals(result.size(), 3);
-        Assert.assertEquals(result.get(0), new Integer(1));
-        Assert.assertEquals(result.get(1), new Integer(2));
-        Assert.assertEquals(result.get(2), new Integer(3));
-
-    }
-
-    @Test
-    public void testWithTimeout() throws ExecutionException, InterruptedException {
-        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-with-timeout");
-        final LazyComposableFuture<String> fast = LazyComposableFuture.schedule(scheduler, () -> "fast", 100, TimeUnit.MILLISECONDS).withTimeout(scheduler, 200, TimeUnit.MILLISECONDS);
-
-        final String res1 = fast.get();
-        Assert.assertEquals(res1, "fast");
-
-        final LazyComposableFuture<String> slow = LazyComposableFuture.schedule(scheduler, () -> "slow", 200, TimeUnit.MILLISECONDS).withTimeout(scheduler, 100, TimeUnit.MILLISECONDS);
-
-        try {
-            slow.get();
-            Assert.fail("should have timed out");
-        } catch (final ExecutionException e) {
-            final Throwable cause = e.getCause();
-            Assert.assertEquals(cause.getClass(), TimeoutException.class);
-        }
-
-        scheduler.shutdown();
-    }
-
-    @Test
-    public void testDoubleDispatch() throws ExecutionException, InterruptedException {
-        final ExecutorService executor = Executors.newFixedThreadPool(2);
-        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-double-dispatch");
-
-        final AtomicBoolean state1 = new AtomicBoolean(false);
-        final LazyComposableFuture<String> res1 = LazyComposableFuture.submit(executor, () -> {
-            if (state1.compareAndSet(false, true)) {
-                Thread.sleep(200);
-                return "first";
-            } else {
-                Thread.sleep(50);
-                return "second";
-            }
-        }, false).doubleDispatch(scheduler, 100, TimeUnit.MILLISECONDS);
-
-        final long t1 = System.currentTimeMillis();
-        final String result1 = res1.get();
-        final long t2 = System.currentTimeMillis();
-
-        Assert.assertEquals(result1, "second");
-        Assert.assertTrue((t2 - t1) < 200);
-
-        final AtomicBoolean state2 = new AtomicBoolean(false);
-        final LazyComposableFuture<String> res2 = LazyComposableFuture.submit(executor, () -> {
-            if (state2.compareAndSet(false, true)) {
-                Thread.sleep(100);
-                return "first";
-            } else {
-                Thread.sleep(50);
-                return "second";
-            }
-        }, false).doubleDispatch(scheduler, 150, TimeUnit.MILLISECONDS);
-
-        final long t3 = System.currentTimeMillis();
-        final String result2 = res2.get();
-        final long t4 = System.currentTimeMillis();
-
-        Assert.assertEquals(result2, "first");
-        Assert.assertTrue((t4 - t3) < 150);
-
-        final AtomicBoolean state3 = new AtomicBoolean(false);
-        final LazyComposableFuture<String> res3 = LazyComposableFuture.submit(executor, () -> {
-            if (state3.compareAndSet(false, true)) {
-                Thread.sleep(100);
-                return "first";
-            } else {
-                Thread.sleep(200);
-                return "second";
-            }
-        }, false).doubleDispatch(scheduler, 50, TimeUnit.MILLISECONDS);
-
-        final long t5 = System.currentTimeMillis();
-        final String result3 = res3.get();
-        final long t6 = System.currentTimeMillis();
-
-        Assert.assertEquals(result3, "first");
-        Assert.assertTrue((t6 - t5) < 200);
-
-        executor.shutdown();
-        scheduler.shutdown();
-    }
-
-    @Test
-    public void testColdStream() {
-        final Scheduler scheduler = new ThreadPoolBasedScheduler(1, "test-cold-stream");
-        final ComposableFuture<String> first = LazyComposableFuture.schedule(scheduler, () -> "first", 100, TimeUnit.MILLISECONDS);
-
-        final ComposableFuture<String> second = LazyComposableFuture.schedule(scheduler, () -> "second", 200, TimeUnit.MILLISECONDS);
-
-        final ComposableFuture<String> third = LazyComposableFuture.schedule(scheduler, () -> "third", 300, TimeUnit.MILLISECONDS);
-
-        final Observable<String> stream = ComposableFutures.toColdObservable(Arrays.asList(first, second, third));
-
-        for (int i = 0; i < 10; i++) {
-            final Iterable<String> results = stream.toBlocking().toIterable();
-            final List<String> resultsList = new ArrayList<>();
-            for (final String result : results) {
-                resultsList.add(result);
-            }
-
-            Assert.assertEquals(resultsList.size(), 3);
-            Assert.assertEquals(resultsList.get(0), "first");
-            Assert.assertEquals(resultsList.get(1), "second");
-            Assert.assertEquals(resultsList.get(2), "third");
-        }
-
-        scheduler.shutdown();
-    }
-
-    @Test
-    public void testTypedErrors() throws Exception {
-        String result = ComposableFutures.<String>submitLazy(false, () -> {
-            throw new FileNotFoundException("no file...");
-        }).recover(NullPointerException.class, error -> {
-            return "failure";
-        }).recover(FileNotFoundException.class, error -> {
-            return "success";
-        }).recover(error -> {
-            return "failure";
-        }).get();
-
-        Assert.assertEquals("success", result);
-
-        String result2 = ComposableFutures.<String>submitLazy(false, () -> {
-            throw new FileNotFoundException("no file...");
-        }).recoverWith(NullPointerException.class, error -> {
-            return ComposableFutures.fromValue("failure");
-        }).recoverWith(FileNotFoundException.class, error -> {
-            return ComposableFutures.fromValue("success");
-        }).recoverWith(error -> {
-            return ComposableFutures.fromValue("failure");
-        }).get();
-
-        Assert.assertEquals("success", result2);
-
-    }
+  }
 
 
-    @Test
-    public void testColdRecursiveStream() {
+  @Test
+  public void testColdRecursiveStream() {
 
-        final AtomicInteger counter = new AtomicInteger(0);
-        final int repeats = 5;
+    final AtomicInteger counter = new AtomicInteger(0);
+    final int repeats = 5;
 
-        final ComposableFuture<String> lazyString = LazyComposableFuture.apply(() -> {
-            counter.incrementAndGet();
-            return "stateless lazy evaluated";
-        });
+    final ComposableFuture<String> lazyString = LazyComposableFuture.apply(() -> {
+      counter.incrementAndGet();
+      return "stateless lazy evaluated";
+    });
 
-        final Observable<String> stringObservable = ComposableFutures.toColdObservable(new RecursiveFutureProvider<String>() {
-            @Override
-            public ComposableFuture<String> provide() {
-                return lazyString;
-            }
+    final Observable<String> stringObservable = ComposableFutures.toColdObservable(new RecursiveFutureProvider<String>() {
+      @Override
+      public ComposableFuture<String> provide() {
+        return lazyString;
+      }
 
-            @Override
-            public Predicate<String> createStopCriteria() {
-                return new Predicate<String>() {
-                    private volatile int i;
+      @Override
+      public Predicate<String> createStopCriteria() {
+        return new Predicate<String>() {
+          private volatile int i;
 
-                    @Override
-                    public boolean apply(final String s) {
-                        return ++i >= repeats;
-                    }
-                };
-            }
-        });
+          @Override
+          public boolean apply(final String s) {
+            return ++i >= repeats;
+          }
+        };
+      }
+    });
 
-        stringObservable.toBlocking().first();
-        stringObservable.toBlocking().first();
+    stringObservable.toBlocking().first();
+    stringObservable.toBlocking().first();
 
-        Assert.assertTrue("counter of evaluations should be 10", counter.get() == repeats * 2);
-    }
+    Assert.assertTrue("counter of evaluations should be 10", counter.get() == repeats * 2);
+  }
 }


### PR DESCRIPTION
allow for a catch block like code that allow to handle different exceptions separately.

the code looks as follow:
`ComposableFuture.submit(() -> {
     // handle IO that might throw different IO related exceptions
}).recover(FileNotFoundException.class, error -> {
     // handle FileNotFoundException
}).recover(FileAlreadyExistsException.class, error -> {
     // recover from this one differently
}).recoverWith(IOException.class, error -> {
    // fail in a more generic way...
}).recoverWith(error -> {
    // catch all still exist and is equivalent to catch(Throwable e)
});`