### PR TITLE
Add setIfAbsent to TypedCached

### DIFF
--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LoadingCacheDelegate.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LoadingCacheDelegate.java
@@ -294,6 +294,11 @@ public class LoadingCacheDelegate<K, V> implements TypedCache<K, V> {
   }
 
   @Override
+  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+    return cache.putIfAbsentAsync(key, value);
+  }
+
+  @Override
   public ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations) {
     return cache.setAsync(key, mapper, maxIterations);
   }

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LoadingCacheDelegate.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LoadingCacheDelegate.java
@@ -294,8 +294,8 @@ public class LoadingCacheDelegate<K, V> implements TypedCache<K, V> {
   }
 
   @Override
-  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
-    return cache.putIfAbsentAsync(key, value);
+  public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
+    return cache.setIfAbsentAsync(key, value);
   }
 
   @Override

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LocalAsyncCache.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LocalAsyncCache.java
@@ -9,6 +9,7 @@ import com.google.common.util.concurrent.ExecutionError;
 import com.outbrain.ob1k.concurrent.ComposableFuture;
 import com.outbrain.ob1k.concurrent.UncheckedExecutionException;
 import com.outbrain.swinfra.metrics.api.MetricFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -16,7 +17,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static com.outbrain.ob1k.concurrent.ComposableFutures.*;
+import static com.outbrain.ob1k.concurrent.ComposableFutures.all;
+import static com.outbrain.ob1k.concurrent.ComposableFutures.fromError;
+import static com.outbrain.ob1k.concurrent.ComposableFutures.fromNull;
+import static com.outbrain.ob1k.concurrent.ComposableFutures.fromValue;
 
 
 /**
@@ -209,6 +213,17 @@ public class LocalAsyncCache<K,V> implements TypedCache<K,V> {
       loadingCache.put(key, fromValue(value));
     } else {
       localCache.put(key, fromValue(value));
+    }
+
+    return fromValue(true);
+  }
+
+  @Override
+  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+    if (loadingCache != null) {
+      loadingCache.asMap().putIfAbsent(key, fromValue(value));
+    } else {
+      localCache.asMap().putIfAbsent(key, fromValue(value));
     }
 
     return fromValue(true);

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LocalAsyncCache.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LocalAsyncCache.java
@@ -220,13 +220,8 @@ public class LocalAsyncCache<K,V> implements TypedCache<K,V> {
 
   @Override
   public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
-    if (loadingCache != null) {
-      loadingCache.asMap().putIfAbsent(key, fromValue(value));
-    } else {
-      localCache.asMap().putIfAbsent(key, fromValue(value));
-    }
-
-    return fromValue(true);
+    final Cache<K, ComposableFuture<V>> cache = loadingCache == null ? localCache : loadingCache;
+    return fromValue(cache.asMap().putIfAbsent(key, fromValue(value)) == null);
   }
 
   @Override

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LocalAsyncCache.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/LocalAsyncCache.java
@@ -219,7 +219,7 @@ public class LocalAsyncCache<K,V> implements TypedCache<K,V> {
   }
 
   @Override
-  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+  public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
     if (loadingCache != null) {
       loadingCache.asMap().putIfAbsent(key, fromValue(value));
     } else {

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/TypedCache.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/TypedCache.java
@@ -16,7 +16,7 @@ public interface TypedCache<K, V> {
 
   ComposableFuture<Boolean> setAsync(final K key, final V value);
 
-  ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value);
+  ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value);
 
   ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations);
 

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/TypedCache.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/TypedCache.java
@@ -10,12 +10,17 @@ import java.util.Map;
  * an interface for local async cache with loader.
  */
 public interface TypedCache<K, V> {
-    ComposableFuture<V> getAsync(final K key);
-    ComposableFuture<Map<K, V>> getBulkAsync(final Iterable<? extends K> keys);
+  ComposableFuture<V> getAsync(final K key);
 
-    ComposableFuture<Boolean> setAsync(final K key, final  V value);
-    ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations);
-    ComposableFuture<Map<K, Boolean>> setBulkAsync(final Map<? extends K, ? extends V> entries);
+  ComposableFuture<Map<K, V>> getBulkAsync(final Iterable<? extends K> keys);
 
-    ComposableFuture<Boolean> deleteAsync(final K key);
+  ComposableFuture<Boolean> setAsync(final K key, final V value);
+
+  ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value);
+
+  ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations);
+
+  ComposableFuture<Map<K, Boolean>> setBulkAsync(final Map<? extends K, ? extends V> entries);
+
+  ComposableFuture<Boolean> deleteAsync(final K key);
 }

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MemcacheClient.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MemcacheClient.java
@@ -94,6 +94,11 @@ public class MemcacheClient<K, V> implements TypedCache<K, V> {
   }
 
   @Override
+  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+    throw new UnsupportedOperationException("Not supported for spy");
+  }
+
+  @Override
   public ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations) {
     return casUpdate(key, mapper).flatMap(result -> {
       if (result == CASResponse.OK || result == CASResponse.OBSERVE_MODIFIED) {

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MemcacheClient.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MemcacheClient.java
@@ -94,7 +94,7 @@ public class MemcacheClient<K, V> implements TypedCache<K, V> {
   }
 
   @Override
-  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+  public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
     throw new UnsupportedOperationException("Not supported for spy");
   }
 

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MemcacheClient.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/MemcacheClient.java
@@ -95,7 +95,7 @@ public class MemcacheClient<K, V> implements TypedCache<K, V> {
 
   @Override
   public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
-    throw new UnsupportedOperationException("Not supported for spy");
+    return SpyFutureHelper.fromOperation(() -> spyClient.add(keyTranslator.translateKey(key), expirationSpyUnits, value));
   }
 
   @Override

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/folsom/MemcachedClient.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/folsom/MemcachedClient.java
@@ -79,12 +79,29 @@ public class MemcachedClient<K, V> implements TypedCache<K, V> {
 
   @Override
   public ComposableFuture<Boolean> setAsync(final K key, final V value) {
+    return setAsync(key, value, expirationSeconds);
+  }
+
+  public ComposableFuture<Boolean> setAsync(final K key, final V value, final int expirationSeconds) {
     return fromListenableFuture(() -> folsomClient.set(key(key), value, expirationSeconds), this::isOK);
   }
 
   @Override
+  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+    return putIfAbsentAsync(key, value, expirationSeconds);
+  }
+
+  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value, final int expirationSeconds) {
+    return fromListenableFuture(() -> folsomClient.add(key(key), value, expirationSeconds), this::isOK);
+  }
+
+  @Override
   public ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations) {
-    return casUpdate(key, mapper).flatMap(result -> {
+    return setAsync(key, mapper, maxIterations, expirationSeconds);
+  }
+
+  public ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations, final int expirationSeconds) {
+    return casUpdate(key, mapper, expirationSeconds).flatMap(result -> {
       if (result == MemcacheStatus.OK) {
         return ComposableFutures.fromValue(true);
       }
@@ -97,7 +114,7 @@ public class MemcachedClient<K, V> implements TypedCache<K, V> {
     });
   }
 
-  private ComposableFuture<MemcacheStatus> casUpdate(final K key, final EntryMapper<K, V> mapper) {
+  private ComposableFuture<MemcacheStatus> casUpdate(final K key, final EntryMapper<K, V> mapper, final int expirationSeconds) {
     try {
       final String stringKey = key(key);
 

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/folsom/MemcachedClient.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/folsom/MemcachedClient.java
@@ -79,29 +79,17 @@ public class MemcachedClient<K, V> implements TypedCache<K, V> {
 
   @Override
   public ComposableFuture<Boolean> setAsync(final K key, final V value) {
-    return setAsync(key, value, expirationSeconds);
-  }
-
-  public ComposableFuture<Boolean> setAsync(final K key, final V value, final int expirationSeconds) {
     return fromListenableFuture(() -> folsomClient.set(key(key), value, expirationSeconds), this::isOK);
   }
 
   @Override
   public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
-    return putIfAbsentAsync(key, value, expirationSeconds);
-  }
-
-  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value, final int expirationSeconds) {
     return fromListenableFuture(() -> folsomClient.add(key(key), value, expirationSeconds), this::isOK);
   }
 
   @Override
   public ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations) {
-    return setAsync(key, mapper, maxIterations, expirationSeconds);
-  }
-
-  public ComposableFuture<Boolean> setAsync(final K key, final EntryMapper<K, V> mapper, final int maxIterations, final int expirationSeconds) {
-    return casUpdate(key, mapper, expirationSeconds).flatMap(result -> {
+    return casUpdate(key, mapper).flatMap(result -> {
       if (result == MemcacheStatus.OK) {
         return ComposableFutures.fromValue(true);
       }
@@ -114,7 +102,7 @@ public class MemcachedClient<K, V> implements TypedCache<K, V> {
     });
   }
 
-  private ComposableFuture<MemcacheStatus> casUpdate(final K key, final EntryMapper<K, V> mapper, final int expirationSeconds) {
+  private ComposableFuture<MemcacheStatus> casUpdate(final K key, final EntryMapper<K, V> mapper) {
     try {
       final String stringKey = key(key);
 

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/folsom/MemcachedClient.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/memcache/folsom/MemcachedClient.java
@@ -87,7 +87,7 @@ public class MemcachedClient<K, V> implements TypedCache<K, V> {
   }
 
   @Override
-  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+  public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
     return putIfAbsentAsync(key, value, expirationSeconds);
   }
 

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/metrics/MonitoringCacheDelegate.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/metrics/MonitoringCacheDelegate.java
@@ -1,14 +1,14 @@
 package com.outbrain.ob1k.cache.metrics;
 
-import java.util.Map;
-import java.util.function.Function;
-
 import com.google.common.collect.Iterables;
 import com.outbrain.ob1k.cache.EntryMapper;
 import com.outbrain.ob1k.cache.TypedCache;
 import com.outbrain.ob1k.concurrent.ComposableFuture;
 import com.outbrain.swinfra.metrics.api.Counter;
 import com.outbrain.swinfra.metrics.api.MetricFactory;
+
+import java.util.Map;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -24,6 +24,7 @@ public class MonitoringCacheDelegate<K, V> implements TypedCache<K, V> {
   private final AsyncOperationMetrics<V> getAsyncMetrics;
   private final AsyncOperationMetrics<Map<K, V>> getBulkAsyncMetrics;
   private final AsyncOperationMetrics<Boolean> setAsyncMetrics;
+  private final AsyncOperationMetrics<Boolean> putIfAbsentAsyncMetrics;
   private final AsyncOperationMetrics<Map<K, Boolean>> setBulkAsyncMetrics;
   private final AsyncOperationMetrics<Boolean> deleteAsyncMetrics;
 
@@ -50,6 +51,7 @@ public class MonitoringCacheDelegate<K, V> implements TypedCache<K, V> {
     getAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".getAsync");
     getBulkAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".getBulkAsync");
     setAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".setAsync");
+    putIfAbsentAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".putIfAbsentAsync");
     setBulkAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".setBulkAsync");
     deleteAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".deleteAsync");
 
@@ -77,6 +79,11 @@ public class MonitoringCacheDelegate<K, V> implements TypedCache<K, V> {
   @Override
   public ComposableFuture<Boolean> setAsync(final K key, final V value) {
     return setAsyncMetrics.update(delegate.setAsync(key, value));
+  }
+
+  @Override
+  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
+    return putIfAbsentAsyncMetrics.update(delegate.putIfAbsentAsync(key, value));
   }
 
   @Override

--- a/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/metrics/MonitoringCacheDelegate.java
+++ b/ob1k-cache/src/main/java/com/outbrain/ob1k/cache/metrics/MonitoringCacheDelegate.java
@@ -24,7 +24,7 @@ public class MonitoringCacheDelegate<K, V> implements TypedCache<K, V> {
   private final AsyncOperationMetrics<V> getAsyncMetrics;
   private final AsyncOperationMetrics<Map<K, V>> getBulkAsyncMetrics;
   private final AsyncOperationMetrics<Boolean> setAsyncMetrics;
-  private final AsyncOperationMetrics<Boolean> putIfAbsentAsyncMetrics;
+  private final AsyncOperationMetrics<Boolean> setIfAbsentAsyncMetrics;
   private final AsyncOperationMetrics<Map<K, Boolean>> setBulkAsyncMetrics;
   private final AsyncOperationMetrics<Boolean> deleteAsyncMetrics;
 
@@ -51,7 +51,7 @@ public class MonitoringCacheDelegate<K, V> implements TypedCache<K, V> {
     getAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".getAsync");
     getBulkAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".getBulkAsync");
     setAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".setAsync");
-    putIfAbsentAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".putIfAbsentAsync");
+    setIfAbsentAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".setIfAbsentAsync");
     setBulkAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".setBulkAsync");
     deleteAsyncMetrics = new AsyncOperationMetrics<>(metricFactory, component + ".deleteAsync");
 
@@ -82,8 +82,8 @@ public class MonitoringCacheDelegate<K, V> implements TypedCache<K, V> {
   }
 
   @Override
-  public ComposableFuture<Boolean> putIfAbsentAsync(final K key, final V value) {
-    return putIfAbsentAsyncMetrics.update(delegate.putIfAbsentAsync(key, value));
+  public ComposableFuture<Boolean> setIfAbsentAsync(final K key, final V value) {
+    return setIfAbsentAsyncMetrics.update(delegate.setIfAbsentAsync(key, value));
   }
 
   @Override

--- a/ob1k-concurrent/README.md
+++ b/ob1k-concurrent/README.md
@@ -42,7 +42,7 @@ mappedValue.consume(resultTry -> {
 
 And that was our first composition!
 
-Take a look at our [code examples](https://github.com/outbrain/ob1k/tree/cf_new_api/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/examples) to see which helpers and best practices should be used with ComposableFuture.
+Take a look at our [code examples](https://github.com/outbrain/ob1k/tree/master/ob1k-concurrent/src/test/java/com/outbrain/ob1k/concurrent/examples) to see which helpers and best practices should be used with ComposableFuture.
 
 ## Helpers
 Besides ComposableFuture, you can find an implementation of [Try](https://github.com/outbrain/ob1k/blob/master/ob1k-concurrent/src/main/java/com/outbrain/ob1k/concurrent/Try.java) also in this package.  


### PR DESCRIPTION
Add setIfAbsent to TypedCache and overload folsom's setAsync with an expiration parameter.
The methods overloaded with an expiration parameter can be added to TypedCache with a default implementation that throws UnsupportedOperationException. However, I'm reluctant to do so, as I lean toward adding the methods to a RemoteCache interface that will extend TypedCache.
Existing local cache implementations seem not to implement variable expiration as a parameter for the various `set` methods, choosing either not to implement it at all (Guava), or implement it at as a pluggable expiration strategy ([Caffeine](https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Expiry.java), [cache2k](https://cache2k.org/docs/1.0/apidocs/cache2k-api/src-html/org/cache2k/expiry/ExpiryPolicy.html))