### PR TITLE
Moving encoder above HttpObjectAggregator

### DIFF
--- a/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/NettyServer.java
+++ b/ob1k-core/src/main/java/com/outbrain/ob1k/server/netty/NettyServer.java
@@ -203,8 +203,8 @@ public class NettyServer implements Server {
       //p.addLast("ssl", new SslHandler(engine));
 
       p.addLast("decoder", new HttpRequestDecoder(16384, 8192, 16384));
-      p.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
       p.addLast("encoder", new HttpResponseEncoder());
+      p.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
 
       p.addLast("chunkedWriter", new ChunkedWriteHandler());
       p.addLast("static", staticFileServerHandler);


### PR DESCRIPTION
From HttpObjectAggregator JavaDoc:

A ChannelHandler that aggregates an HttpMessage and its following HttpContents into a single FullHttpRequest or FullHttpResponse (depending on if it used to handle requests or responses) with no following HttpContents. It is useful when you don't want to take care of HTTP messages whose transfer encoding is 'chunked'. Insert this handler after HttpObjectDecoder in the ChannelPipeline:
 ChannelPipeline p = ...;
 ...
 p.addLast("encoder", new HttpResponseEncoder());
 p.addLast("decoder", new HttpRequestDecoder());
 p.addLast("aggregator", new HttpObjectAggregator(1048576));
 ...
 p.addLast("handler", new HttpRequestHandler());