### PR TITLE
add an experimental package that uses jasync-sql

### DIFF
--- a/ob1k-db/pom.xml
+++ b/ob1k-db/pom.xml
@@ -30,6 +30,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.jasync-sql</groupId>
+      <artifactId>jasync-mysql</artifactId>
+      <version>0.8.12</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
       <!-- this is an optional dependency - needed only if the package springsupport is used -->

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/BasicDao.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/BasicDao.java
@@ -1,0 +1,390 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.github.jasync.sql.db.QueryResult;
+import com.github.jasync.sql.db.ResultSet;
+import com.github.jasync.sql.db.RowData;
+import com.google.common.base.Joiner;
+import com.outbrain.ob1k.concurrent.ComposableFuture;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Lists.transform;
+import static java.util.Collections.singletonList;
+
+/**
+ * @author Asy Ronen
+ * @author Eran Harel
+ */
+public class BasicDao {
+  private final DbConnectionPool _pool;
+
+  public BasicDao(final DbConnectionPool pool) {
+    this._pool = pool;
+  }
+
+  /**
+   * @param query SQL query to execute
+   * @param keyMapper a mapper between the the value object to the map key
+   * @param valueMapper a mapper between the resultset row, and the returned value(s)
+   * @param <V> map values type
+   * @param <K> map keys type
+   * @return a mapping of the result set mapping each row using the provided keyMapper and valueMapper
+   * @throws IllegalStateException if the result set contains a duplicate key
+   */
+  public <K, V> ComposableFuture<Map<K, V>> map(final String query, final Function<V, K> keyMapper, final ResultSetMapper<V> valueMapper) {
+    return toMap(list(query, valueMapper), keyMapper);
+  }
+
+  /**
+   * @param conn connection to be used to execute the query
+   * @param query SQL query to execute
+   * @param keyMapper a mapper between the the value object to the map key
+   * @param valueMapper a mapper between the resultset row, and the returned value(s)
+   * @param <V> map values type
+   * @param <K> map keys type
+   * @return a mapping of the result set mapping each row using the provided keyMapper and valueMapper
+   * @throws IllegalStateException if the result set contains a duplicate key
+   */
+  public <K, V> ComposableFuture<Map<K, V>> map(final MySqlAsyncConnection conn, final String query, final Function<V, K> keyMapper, final ResultSetMapper<V> valueMapper) {
+    return toMap(list(conn, query, valueMapper), keyMapper);
+  }
+
+  private <K, V> ComposableFuture<Map<K, V>> toMap(final ComposableFuture<List<V>> list, final Function<V, K> keyMapper) {
+    return list.map(result -> result.stream().
+      collect(Collectors.toMap(keyMapper, Function.identity())));
+  }
+
+  /**
+   * @param query SQL query to execute
+   * @param keyMapper a mapper between the the value object to the map key
+   * @param valueMapper a mapper between the resultset row, and the returned value(s)
+   * @param <V> map values type
+   * @param <K> map keys type
+   * @return a mapping of the result set mapping each row using the provided keyMapper and valueMapper, grouping values by key
+   */
+  public <K, V> ComposableFuture<Map<K, List<V>>> group(final String query, final Function<V, K> keyMapper, final ResultSetMapper<V> valueMapper) {
+    return toGroupMap(list(query, valueMapper), keyMapper);
+  }
+
+  /**
+   * @param conn connection to be used to execute the query
+   * @param query SQL query to execute
+   * @param keyMapper a mapper between the the value object to the map key
+   * @param valueMapper a mapper between the resultset row, and the returned value(s)
+   * @param <V> map values type
+   * @param <K> map keys type
+   * @return a mapping of the result set mapping each row using the provided keyMapper and valueMapper, grouping values by key
+   */
+  public <K, V> ComposableFuture<Map<K, List<V>>> group(final MySqlAsyncConnection conn, final String query, final Function<V, K> keyMapper, final ResultSetMapper<V> valueMapper) {
+    return toGroupMap(list(conn, query, valueMapper), keyMapper);
+  }
+
+  private <K, V> ComposableFuture<Map<K, List<V>>> toGroupMap(final ComposableFuture<List<V>> list, final Function<V, K> keyMapper) {
+    return list.map(result -> result.stream().
+      collect(Collectors.groupingBy(keyMapper)));
+  }
+
+  public ComposableFuture<List<Map<String, Object>>> list(final String query) {
+    return list(query, new GenericResultSetMapper());
+  }
+
+  public ComposableFuture<List<Map<String, Object>>> list(final MySqlAsyncConnection conn, final String query) {
+    return list(conn, query, new GenericResultSetMapper());
+  }
+
+  public <T> ComposableFuture<List<T>> list(final String query, final ResultSetMapper<T> mapper) {
+    final ComposableFuture<QueryResult> queryRes = _pool.sendQuery(query);
+    return _list(queryRes, mapper);
+  }
+
+  private <T> ComposableFuture<List<T>> _list(final ComposableFuture<QueryResult> queryRes, final ResultSetMapper<T> mapper) {
+    return queryRes.map(res -> {
+      final Optional<ResultSet> rowsOption = Optional.ofNullable(res.getRows());
+
+      final List<T> response = new ArrayList<>();
+      if (rowsOption.isPresent()) {
+        final ResultSet resultSet = rowsOption.get();
+        final List<String> columnNames = resultSet.columnNames();
+
+        final Iterator<RowData> rows = resultSet.iterator();
+        while (rows.hasNext()) {
+          final RowData row = rows.next();
+          final T obj = mapper.map(new TypedRowData(row), columnNames);
+          response.add(obj);
+        }
+      }
+
+      return response;
+    });
+  }
+
+  public <T> ComposableFuture<List<T>> list(final MySqlAsyncConnection conn, final String query, final ResultSetMapper<T> mapper) {
+    final ComposableFuture<QueryResult> queryRes = conn.sendQuery(query);
+    return _list(queryRes, mapper);
+  }
+
+  public <T> ComposableFuture<List<T>> list(final String tableName, final String idColumnName, final List<?> ids, final ResultSetMapper<T> mapper) {
+    return list(createListByIDsQuery(tableName, idColumnName, ids), mapper);
+  }
+
+  private String createListByIDsQuery(final String tableName, final String idColumnName, final List<?> ids) {
+    return createQueryForIds("select * from", tableName, idColumnName, ids);
+  }
+
+  private String createQueryForIds(final String baseQuery, final String tableName, final String idColumnName,
+                                   final List<?> ids) {
+    final StringBuilder query = new StringBuilder(baseQuery);
+    query.append(' ');
+    query.append(withBackticks(tableName));
+    query.append(" where ");
+    query.append(withBackticks(idColumnName));
+    query.append(" in (");
+    final Joiner joiner = Joiner.on(',');
+    joiner.appendTo(query, transform(ids, BasicDao::withQuote)); // todo: why it's not just List<String> ?
+    query.append(");");
+
+    return query.toString();
+  }
+
+  public <T> ComposableFuture<List<T>> list(final MySqlAsyncConnection conn, final String tableName, final String idColumnName,
+                                            final List<?> ids, final ResultSetMapper<T> mapper) {
+    final ComposableFuture<QueryResult> queryRes = conn.sendQuery(createListByIDsQuery(tableName, idColumnName, ids));
+    return _list(queryRes, mapper);
+  }
+
+  //  public <T> ComposableFuture<T> get(final String tableName, String idColumnName, Object id, final ResultSetMapper<T> mapper) {
+  //    ???
+  //  }
+
+  public <T> ComposableFuture<T> get(final String query, final ResultSetMapper<T> mapper) {
+    final ComposableFuture<QueryResult> queryRes = _pool.sendQuery(query);
+    return _get(queryRes, mapper);
+  }
+
+  private <T> ComposableFuture<T> _get(final ComposableFuture<QueryResult> queryRes, final ResultSetMapper<T> mapper) {
+    return queryRes.map(res -> {
+      final Optional<ResultSet> rowsOption = Optional.ofNullable(res.getRows());
+
+      if (rowsOption.isPresent()) {
+        final ResultSet resultSet = rowsOption.get();
+
+        final Iterator<RowData> rows = resultSet.iterator();
+        if (rows.hasNext()) {
+          final RowData row = rows.next();
+          return mapper.map(new TypedRowData(row), resultSet.columnNames());
+        }
+      }
+
+      return null;
+    });
+  }
+
+  public <T> ComposableFuture<T> get(final MySqlAsyncConnection conn, final String query, final ResultSetMapper<T> mapper) {
+    final ComposableFuture<QueryResult> queryRes = conn.sendQuery(query);
+    return _get(queryRes, mapper);
+  }
+
+  public <T> ComposableFuture<T> withConnection(final TransactionHandler<T> handler) {
+    return _pool.withConnection(handler);
+  }
+
+  public <T> ComposableFuture<T> withTransaction(final TransactionHandler<T> handler) {
+    return _pool.withTransaction(handler);
+  }
+
+  public <T> ComposableFuture<T> get(final ResultSetMapper<T> mapper, final String tableName, final int limit) {
+    return get("select * from " + withBackticks(tableName) + " limit " + limit, mapper);
+  }
+
+  public <T> ComposableFuture<T> get(final MySqlAsyncConnection conn, final ResultSetMapper<T> mapper, final String tableName, final int limit) {
+    return get(conn, "select * from " + withBackticks(tableName) + " limit " + limit, mapper);
+  }
+
+  public ComposableFuture<Map<String, Object>> get(final String query) {
+    return get(query, new GenericResultSetMapper());
+  }
+
+  public ComposableFuture<Map<String, Object>> get(final MySqlAsyncConnection conn, final String query) {
+    return get(conn, query, new GenericResultSetMapper());
+  }
+
+  public ComposableFuture<Long> execute(final String command) {
+    final ComposableFuture<QueryResult> queryRes = _pool.sendQuery(command);
+    return _execute(queryRes);
+  }
+
+  public ComposableFuture<Long> executeAndGetId(final String command) {
+    return withConnection(conn -> execute(conn, command)
+      .flatMap(result -> get(conn, "select LAST_INSERT_ID()"))
+      .map(result -> (Long) result.get("LAST_INSERT_ID()")));
+  }
+
+  public <T> ComposableFuture<Long> saveAndGetId(final T entry, final String tableName, final EntityMapper<T> mapper) {
+    final String saveCommand = createSaveCommand(singletonList(entry), tableName, mapper);
+    return executeAndGetId(saveCommand);
+  }
+
+  public ComposableFuture<Long> execute(final MySqlAsyncConnection conn, final String command) {
+    final ComposableFuture<QueryResult> queryRes = conn.sendQuery(command);
+    return _execute(queryRes);
+  }
+
+  private ComposableFuture<Long> _execute(final ComposableFuture<QueryResult> queryRes) {
+    return queryRes.map(QueryResult::getRowsAffected);
+  }
+
+  public ComposableFuture<Long> delete(final String tableName, final String idColumnName, final Object id) {
+    return execute(createDeleteCommand(tableName, idColumnName, singletonList(id)));
+  }
+
+  public ComposableFuture<Long> delete(final MySqlAsyncConnection conn, final String tableName,
+                                       final String idColumnName, final Object id) {
+    return execute(conn, createDeleteCommand(tableName, idColumnName, singletonList(id)));
+  }
+
+  public ComposableFuture<Long> delete(final String tableName, final String idColumnName, final List<?> ids) {
+    return execute(createDeleteCommand(tableName, idColumnName, ids));
+  }
+
+  public ComposableFuture<Long> delete(final MySqlAsyncConnection conn, final String tableName,
+                                       final String idColumnName, final List<?> ids) {
+    return execute(conn, createDeleteCommand(tableName, idColumnName, ids));
+  }
+
+  private String createDeleteCommand(final String tableName, final String idColumnName, final List<?> ids) {
+    return createQueryForIds("delete from", tableName, idColumnName, ids);
+  }
+
+  public <T> ComposableFuture<Long> save(final List<T> entries, final String tableName, final EntityMapper<T> mapper) {
+    return execute(createSaveCommand(entries, tableName, mapper));
+  }
+
+  public <T> ComposableFuture<Long> save(final MySqlAsyncConnection conn, final List<T> entries, final String tableName, final EntityMapper<T> mapper) {
+    return execute(conn, createSaveCommand(entries, tableName, mapper));
+  }
+
+  /**
+   * Updates entry/entries of table by provided values &amp; conditions
+   *
+   * @param tableName table name to update values of
+   * @param entry entry to update by
+   * @param entryMapper a mapper between the the value object to the map key
+   * @param idMapper a mapper between the condition column to update by to the value (.. where column=value)
+   * @param <T> entry generic
+   * @return number of updated entries
+   */
+  public <T> ComposableFuture<Long> update(final String tableName, final T entry, final EntityMapper<T> entryMapper,
+                                           final EntityMapper<T> idMapper) {
+    return execute(createUpdateCommand(tableName, entry, entryMapper, idMapper));
+  }
+
+  /**
+   * Updates entry/entries of table by provided values &amp; conditions
+   *
+   * @param conn connection to be used to execute the query
+   * @param tableName table name to update values of
+   * @param entry entry to update by
+   * @param entryMapper a mapper between the the value object to the map key
+   * @param idMapper a mapper between the condition column to update by to the value (.. where column=value)
+   * @param <T> entry generic
+   * @return number of updated entries
+   */
+  public <T> ComposableFuture<Long> update(final MySqlAsyncConnection conn, final String tableName, final T entry,
+                                           final EntityMapper<T> entryMapper, final EntityMapper<T> idMapper) {
+    return execute(conn, createUpdateCommand(tableName, entry, entryMapper, idMapper));
+  }
+
+  private <T> String createUpdateCommand(final String tableName, final T entry, final EntityMapper<T> entryMapper,
+                                         final EntityMapper<T> idMapper) {
+    final StringBuilder command = new StringBuilder("update ");
+    command.append(withBackticks(tableName));
+    command.append(" set ");
+
+    final Map<String, Object> updateValues = entryMapper.map(entry);
+    final String entriesToUpdate = toColumnValueString(updateValues, ", ");
+
+    command.append(entriesToUpdate);
+    command.append("where ");
+
+    final Map<String, Object> updateByEntries = idMapper.map(entry);
+    final String updateBy = toColumnValueString(updateByEntries, " and ");
+
+    command.append(updateBy);
+    command.append(";");
+
+    return command.toString();
+  }
+
+  private String toColumnValueString(final Map<String, Object> updateValues, final String seperator) {
+    return updateValues.entrySet().stream().map(entry ->
+      withBackticks(entry.getKey()) + "=" + withQuote(entry.getValue())).
+      collect(Collectors.joining(seperator));
+  }
+
+  private <T> String createSaveCommand(final List<T> entries, final String tableName, final EntityMapper<T> mapper) {
+    // using the following syntax: INSERT INTO tbl_name (a,b,c) VALUES(1,2,3),(4,5,6),(7,8,9);
+
+    if (entries == null || entries.isEmpty())
+      throw new IllegalArgumentException("entries must contain at least on entry");
+
+    final StringBuilder command = new StringBuilder("insert into ");
+    command.append(withBackticks(tableName));
+
+    // setting the columns part (col1, col2, ...)
+    command.append(" (");
+    final T first = entries.get(0);
+    final List<String> columnNames = new ArrayList<>(mapper.map(first).keySet());
+    final Joiner joiner = Joiner.on(',');
+    joiner.appendTo(command, transform(columnNames, BasicDao::withBackticks));
+    command.append(") ");
+
+    command.append(" values ");
+
+    // setting the values part values (val11, val12, ...), (val21, val22, ...), ...
+    for (final T entry : entries) {
+      if (entry != first)
+        command.append(",");
+
+      command.append(" (");
+      final List<String> values = new ArrayList<>();
+      final Map<String, Object> elements = mapper.map(entry);
+      for (final String column : columnNames) {
+        final Object value = elements.get(column);
+        if (value != null) {
+          final String queryValue = withQuote(value);
+          values.add(queryValue);
+        } else {
+          values.add("NULL");
+        }
+      }
+
+      joiner.appendTo(command, values);
+      command.append(") ");
+    }
+
+    command.append(";");
+    return command.toString();
+  }
+
+  public ComposableFuture<Boolean> shutdown() {
+    return _pool.close();
+  }
+
+  private static String withBackticks(final String columnOrTable) {
+    return "`" + columnOrTable + "`";
+  }
+
+  private static String withQuote(final Object value) {
+    if (value instanceof Boolean) {
+      return value.toString();
+    }
+
+    return "'" + value + "'";
+  }
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/DbConnectionPool.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/DbConnectionPool.java
@@ -1,0 +1,21 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.github.jasync.sql.db.QueryResult;
+import com.outbrain.ob1k.concurrent.ComposableFuture;
+
+import java.util.List;
+
+/**
+ * Created by eran on 3/25/15.
+ */
+public interface DbConnectionPool {
+  ComposableFuture<QueryResult> sendQuery(String query);
+
+  ComposableFuture<QueryResult> sendPreparedStatement(String query, List<Object> values);
+
+  <T> ComposableFuture<T> withConnection(TransactionHandler<T> handler);
+
+  <T> ComposableFuture<T> withTransaction(TransactionHandler<T> handler);
+
+  ComposableFuture<Boolean> close();
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/EntityMapper.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/EntityMapper.java
@@ -1,0 +1,12 @@
+package com.outbrain.ob1k.db.experimental;
+
+import java.util.Map;
+
+/**
+ * User: aronen
+ * Date: 11/11/13
+ * Time: 4:39 PM
+ */
+public interface EntityMapper<T> {
+  Map<String, Object> map(T entity);
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/GenericResultSetMapper.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/GenericResultSetMapper.java
@@ -1,0 +1,24 @@
+package com.outbrain.ob1k.db.experimental;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * User: aronen
+ * Date: 9/22/13
+ * Time: 4:36 PM
+ */
+public class GenericResultSetMapper implements ResultSetMapper<Map<String, Object>> {
+
+  @Override
+  public Map<String, Object> map(final TypedRowData row, final List<String> columnNames) {
+    final HashMap<String, Object> rowMap = new HashMap<>();
+    for (final String columnName: columnNames) {
+      final Object val = row.getRaw(columnName);
+      rowMap.put(columnName, val);
+    }
+
+    return rowMap;
+  }
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/JavaFutureHelper.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/JavaFutureHelper.java
@@ -1,0 +1,32 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.outbrain.ob1k.concurrent.ComposableFuture;
+import com.outbrain.ob1k.concurrent.ComposableFutures;
+import com.outbrain.ob1k.concurrent.Try;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * User: aronen
+ * Date: 9/17/13
+ * Time: 3:43 PM
+ */
+public class JavaFutureHelper {
+
+  public interface FutureProvider<T> {
+    CompletableFuture<T> provide();
+  }
+
+  public static <T> ComposableFuture<T> from(final FutureProvider<T> source) {
+    return ComposableFutures.build(consumer -> {
+      final CompletableFuture<T> future = source.provide();
+      future.whenCompleteAsync((v, t) -> {
+        if (t == null) {
+          consumer.consume(Try.fromValue(v));
+        } else {
+          consumer.consume(Try.fromError(t));
+        }
+      }, ComposableFutures.getExecutor());
+    });
+  }
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/MySqlAsyncConnection.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/MySqlAsyncConnection.java
@@ -1,0 +1,96 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.github.jasync.sql.db.Configuration;
+import com.github.jasync.sql.db.Connection;
+import com.github.jasync.sql.db.QueryResult;
+import com.github.jasync.sql.db.SSLConfiguration;
+import com.github.jasync.sql.db.mysql.MySQLConnection;
+import com.outbrain.ob1k.concurrent.ComposableFuture;
+import com.outbrain.ob1k.concurrent.ComposableFutures;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.CharsetUtil;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+
+/**
+ * User: aronen
+ * Date: 9/17/13
+ * Time: 4:55 PM
+ */
+public class MySqlAsyncConnection {
+  public static final int MAXIMUM_MESSAGE_SIZE = 16*1024*1024;
+  private final MySQLConnection conn;
+
+  public MySqlAsyncConnection(final MySQLConnection conn) {
+    this.conn = conn;
+  }
+
+  public static Configuration createConfiguration(final String host, final int port, final Optional<String> database, final String userName, final Optional<String> password,
+                                                  final long connectTimeoutMilliSeconds, final long queryTimeoutMilliSeconds) {
+    final Optional<Duration> queryTimeout = queryTimeoutMilliSeconds == -1 ?
+      Optional.empty() :
+      Optional.of(Duration.ofMillis(queryTimeoutMilliSeconds));
+
+    return new Configuration(userName, host, port, password.orElse(null), database.orElse(null), new SSLConfiguration(), CharsetUtil.UTF_8, MAXIMUM_MESSAGE_SIZE,
+      PooledByteBufAllocator.DEFAULT, Duration.ofMillis(connectTimeoutMilliSeconds), Duration.ofSeconds(4),
+      queryTimeout.orElse(null));
+  }
+
+  MySQLConnection getInnerConnection() {
+    return conn;
+  }
+
+  public ComposableFuture<QueryResult> sendQuery(final String query) {
+    return JavaFutureHelper.from(() -> conn.sendQuery(query));
+  }
+
+  public ComposableFuture<QueryResult> sendPreparedStatement(final String query, final List<Object> values) {
+    return JavaFutureHelper.from(() -> conn.sendPreparedStatement(query, values));
+  }
+
+  public ComposableFuture<MySqlAsyncConnection> connect() {
+    if (conn.isConnected()) {
+      return ComposableFutures.fromValue(this);
+    }
+
+    final ComposableFuture<Connection> composableFuture = JavaFutureHelper.from(conn::connect);
+
+    return composableFuture.map(result -> {
+      final MySQLConnection connection = (MySQLConnection) result;
+      if (connection == conn) {
+        return MySqlAsyncConnection.this;
+      } else {
+        return new MySqlAsyncConnection(connection);
+      }
+    });
+  }
+
+  public ComposableFuture<MySqlAsyncConnection> startTx() {
+    return this.sendQuery("START TRANSACTION;").flatMap(result -> ComposableFutures.fromValue(MySqlAsyncConnection.this));
+  }
+
+  public ComposableFuture<QueryResult> commit() {
+    return this.sendQuery("COMMIT;");
+  }
+
+  public ComposableFuture<QueryResult> rollBack() {
+    return this.sendQuery("ROLLBACK;");
+  }
+
+  public ComposableFuture<MySqlAsyncConnection> disconnect() {
+    final ComposableFuture<Connection> composableFuture = JavaFutureHelper.from(conn::disconnect);
+
+    return composableFuture.map(result -> {
+      final MySQLConnection connection = (MySQLConnection) result;
+      if (connection == conn) {
+        return MySqlAsyncConnection.this;
+      } else {
+        return new MySqlAsyncConnection(connection);
+      }
+    });
+  }
+
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/MySqlConnectionPool.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/MySqlConnectionPool.java
@@ -1,0 +1,109 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.github.jasync.sql.db.QueryResult;
+import com.github.jasync.sql.db.mysql.MySQLConnection;
+import com.github.jasync.sql.db.mysql.pool.MySQLConnectionFactory;
+import com.github.jasync.sql.db.pool.AsyncObjectPool;
+import com.github.jasync.sql.db.pool.ConnectionPool;
+import com.github.jasync.sql.db.pool.PoolConfiguration;
+import com.outbrain.ob1k.concurrent.ComposableFuture;
+import com.outbrain.ob1k.concurrent.ComposableFutures;
+import com.outbrain.ob1k.concurrent.Try;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static com.outbrain.ob1k.concurrent.ComposableFutures.fromError;
+import static com.outbrain.ob1k.concurrent.ComposableFutures.fromValue;
+
+/**
+ * User: aronen
+ * Date: 9/22/13
+ * Time: 5:59 PM
+ */
+class MySqlConnectionPool implements DbConnectionPool {
+  private static final Logger logger = LoggerFactory.getLogger(MySqlConnectionPool.class);
+
+  private final ConnectionPool<MySQLConnection> _pool;
+
+  MySqlConnectionPool(final MySQLConnectionFactory connFactory, final PoolConfiguration poolConfiguration, final MetricFactory metricFactory) {
+    _pool = new ConnectionPool<>(connFactory, poolConfiguration, ComposableFutures.getExecutor());
+    initializeMetrics(metricFactory, _pool);
+  }
+
+
+  private static void initializeMetrics(final MetricFactory metricFactory, final ConnectionPool<MySQLConnection> pool) {
+    if (metricFactory != null) {
+      metricFactory.registerGauge("MysqlAsyncConnectionPool", "available", () -> pool.availables().size());
+      metricFactory.registerGauge("MysqlAsyncConnectionPool", "waiting", () -> pool.queued().size());
+      metricFactory.registerGauge("MysqlAsyncConnectionPool", "inUse", () -> pool.inUse().size());
+    }
+  }
+
+  @Override
+  public ComposableFuture<QueryResult> sendQuery(final String query) {
+    return JavaFutureHelper.from(() -> _pool.sendQuery(query));
+  }
+
+  @Override
+  public ComposableFuture<QueryResult> sendPreparedStatement(final String query, final List<Object> values) {
+    return JavaFutureHelper.from(() -> _pool.sendPreparedStatement(query, values));
+  }
+
+  private ComposableFuture<MySqlAsyncConnection> take() {
+    final ComposableFuture<MySQLConnection> connFuture = JavaFutureHelper.from(_pool::take);
+
+    return connFuture.map(MySqlAsyncConnection::new);
+  }
+
+  private ComposableFuture<Boolean> giveBack(final MySqlAsyncConnection conn) {
+    return JavaFutureHelper.from(() -> _pool.giveBack(conn.getInnerConnection())).always(Try::isSuccess);
+  }
+
+  @Override
+  public <T> ComposableFuture<T> withConnection(final TransactionHandler<T> handler) {
+    final ComposableFuture<MySqlAsyncConnection> futureConn = take();
+    return futureConn.flatMap(conn ->
+      handler.handle(conn).
+        alwaysWith(result -> giveBack(conn).
+          alwaysWith(giveBackResult -> ComposableFutures.fromTry(result))));
+  }
+
+  @Override
+  public <T> ComposableFuture<T> withTransaction(final TransactionHandler<T> handler) {
+    final ComposableFuture<MySqlAsyncConnection> futureConn = take();
+    return futureConn.flatMap(conn -> conn.startTx().
+      flatMap(result -> handler.handle(conn)).
+      flatMap(result -> conn.commit().
+        alwaysWith(commitResult -> giveBack(conn).
+          alwaysWith(giveBackResult -> {
+            if (!giveBackResult.isSuccess()) {
+              logger.warn("can't return connection back to pool", giveBackResult.getError());
+            }
+
+            if (commitResult.isSuccess()) {
+              return fromValue(result);
+            } else {
+              return fromError(commitResult.getError());
+            }
+          })
+        )
+      ).recoverWith(error -> conn.rollBack().alwaysWith(rollBackResult -> giveBack(conn).
+        alwaysWith(result -> {
+          if (!result.isSuccess()) {
+            logger.warn("can't return connection back to pool", error);
+          }
+          return fromError(error);
+        })
+      )
+    ));
+  }
+
+  @Override
+  public ComposableFuture<Boolean> close() {
+    final ComposableFuture<AsyncObjectPool<MySQLConnection>> future = JavaFutureHelper.from(_pool::close);
+    return future.always(Try::isSuccess);
+  }
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/MySqlConnectionPoolBuilder.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/MySqlConnectionPoolBuilder.java
@@ -1,0 +1,129 @@
+package com.outbrain.ob1k.db.experimental;
+
+
+import com.github.jasync.sql.db.mysql.pool.MySQLConnectionFactory;
+import com.github.jasync.sql.db.pool.PoolConfiguration;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+
+import java.util.Optional;
+
+/**
+ * Builds a MySql {@link DbConnectionPool}.
+ *
+ * @author Eran Harel
+ */
+public class MySqlConnectionPoolBuilder {
+
+  private final String host;
+  private final int port;
+  private final String username;
+  private MySQLConnectionFactory connectionFactory;
+  private Optional<String> password = Optional.empty();
+  private Optional<String> database = Optional.empty();
+  private long connectTimeoutMilliSeconds = 2000;
+  private long queryTimeoutMilliSeconds = -1;
+  private int maxConnections = 10;
+  private Optional<Integer> maxQueueSize = Optional.empty();
+
+  private long maxIdleTimeMs = 15 * 60 * 1000;
+  private long validationIntervalMs = 30 * 1000;
+
+  private MetricFactory metricFactory;
+
+  private MySqlConnectionPoolBuilder(final String host, final  int port, final String username) {
+    this.host = host;
+    this.port = port;
+    this.username = username;
+  }
+
+  private MySqlConnectionPoolBuilder(final MySQLConnectionFactory connectionFactory) {
+    this.connectionFactory = connectionFactory;
+    this.host = null;
+    this.port = -1;
+    this.username = null;
+  }
+
+  public static MySqlConnectionPoolBuilder newBuilder(final MySQLConnectionFactory connectionFactory) {
+    return new MySqlConnectionPoolBuilder(connectionFactory);
+  }
+
+  /**
+   * @param host DB host
+   * @param username user name for login.
+   * @param port DB port
+   */
+  public static MySqlConnectionPoolBuilder newBuilder(final String host, final int port, final String username) {
+    return new MySqlConnectionPoolBuilder(host, port, username);
+  }
+
+  /**
+   * Warning - Use only when the connection string is in host:port format without schema and other parameter.
+   * example: mydb.company.com:3308
+   *
+   * @param connectionString host:port
+   * @param username         user name for login.
+   */
+  public static MySqlConnectionPoolBuilder newBuilder(final String connectionString, final String username) {
+    final String[] arr = connectionString.split(":");
+    final String host = arr[0];
+    final int port = Integer.parseInt(arr[1]);
+    return newBuilder(host, port, username);
+  }
+
+
+  public MySqlConnectionPoolBuilder forDatabase(final String database) {
+    this.database = Optional.ofNullable(database);
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder password(final String password) {
+    this.password = Optional.ofNullable(password);
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder connectTimeout(final long connectTimeoutMilliSeconds) {
+    this.connectTimeoutMilliSeconds = connectTimeoutMilliSeconds;
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder queryTimeout(final long queryTimeoutMilliSeconds) {
+    this.queryTimeoutMilliSeconds = queryTimeoutMilliSeconds;
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder maxConnections(final int maxConnections) {
+    this.maxConnections = maxConnections;
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder maxQueueSize(final Integer maxQueueSize) {
+    this.maxQueueSize = Optional.ofNullable(maxQueueSize);
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder maxIdleTimeMs(final Integer maxIdleTimeMs) {
+    this.maxIdleTimeMs = maxIdleTimeMs;
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder validationIntervalMs(final Integer validationIntervalMs) {
+    this.validationIntervalMs = validationIntervalMs;
+    return this;
+  }
+
+  public MySqlConnectionPoolBuilder withMetrics(final MetricFactory metricFactory) {
+    this.metricFactory = metricFactory;
+    return this;
+  }
+
+  public DbConnectionPool build() {
+    final MySQLConnectionFactory connFactory = connectionFactory == null ?
+            new MySQLConnectionFactory(MySqlAsyncConnection.createConfiguration(host, port, database, username, password,
+              connectTimeoutMilliSeconds, queryTimeoutMilliSeconds))
+            : connectionFactory;
+    final int finalMaxQueueSize = !maxQueueSize.isPresent() ? maxConnections * 2 : maxQueueSize.get();
+    final PoolConfiguration configuration = new PoolConfiguration(maxConnections, maxIdleTimeMs, finalMaxQueueSize, validationIntervalMs);
+
+    return new MySqlConnectionPool(connFactory, configuration, metricFactory);
+  }
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/ResultSetMapper.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/ResultSetMapper.java
@@ -1,0 +1,12 @@
+package com.outbrain.ob1k.db.experimental;
+
+import java.util.List;
+
+/**
+ * User: aronen
+ * Date: 9/22/13
+ * Time: 4:30 PM
+ */
+public interface ResultSetMapper<T> {
+  T map(TypedRowData row, List<String> columnNames);
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/SqlSanitizer.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/SqlSanitizer.java
@@ -1,0 +1,75 @@
+package com.outbrain.ob1k.db.experimental;
+
+/**
+ * Provides basic utility to filter inputs when preparing SQL statements
+ *
+ * @author marenzon
+ */
+public class SqlSanitizer {
+
+  private SqlSanitizer() {
+  }
+
+  public static String escapeInput(final String input) {
+    if (input == null) {
+      return null;
+    }
+
+    final int inputLength = input.length();
+    final StringBuilder sanitizedInput = new StringBuilder((int) (inputLength * 1.1));
+
+    // This code is taken from official MySQL j/connector driver
+    for (int i = 0; i < inputLength; ++i) {
+      final char c = input.charAt(i);
+
+      switch (c) {
+        case '\0': /* Must be escaped for 'mysql' */
+          sanitizedInput.append('\\');
+          sanitizedInput.append('0');
+
+          break;
+
+        case '\n': /* Must be escaped for logs */
+          sanitizedInput.append('\\');
+          sanitizedInput.append('n');
+
+          break;
+
+        case '\r':
+          sanitizedInput.append('\\');
+          sanitizedInput.append('r');
+
+          break;
+
+        case '\\':
+          sanitizedInput.append('\\');
+          sanitizedInput.append('\\');
+
+          break;
+
+        case '\'':
+          sanitizedInput.append('\\');
+          sanitizedInput.append('\'');
+
+          break;
+
+        case '"': /* Better safe than sorry */
+          sanitizedInput.append('\\');
+          sanitizedInput.append('"');
+
+          break;
+
+        case '\032': /* This gives problems on Win32 */
+          sanitizedInput.append('\\');
+          sanitizedInput.append('Z');
+
+          break;
+
+        default:
+          sanitizedInput.append(c);
+      }
+    }
+
+    return sanitizedInput.toString();
+  }
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/TransactionHandler.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/TransactionHandler.java
@@ -1,0 +1,12 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.outbrain.ob1k.concurrent.ComposableFuture;
+
+/**
+ * User: aronen
+ * Date: 11/4/13
+ * Time: 6:41 PM
+ */
+public interface TransactionHandler<T> {
+  ComposableFuture<T> handle(MySqlAsyncConnection conn);
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/TypedRowData.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/TypedRowData.java
@@ -1,0 +1,97 @@
+package com.outbrain.ob1k.db.experimental;
+
+import com.github.jasync.sql.db.RowData;
+import org.joda.time.LocalDateTime;
+
+import java.util.Objects;
+
+/**
+ * User: aronen
+ * Date: 10/1/13
+ * Time: 2:11 PM
+ */
+public class TypedRowData {
+  private final RowData row;
+
+  public TypedRowData(final RowData row) {
+    this.row = row;
+  }
+
+  public Integer getInt(final int column) {
+    return (Integer) row.get(column);
+  }
+
+  public Integer getInt(final String column) {
+    return (Integer) row.get(column);
+  }
+
+  public Long getLong(final int column) {
+    return (Long) row.get(column);
+  }
+
+  public Long getLong(final String column) {
+    return (Long) row.get(column);
+  }
+
+  public Boolean getBoolean(final int column) {
+    return ((byte[]) Objects.requireNonNull(row.get(column)))[0] == 1;
+  }
+
+  public Boolean getBoolean(final String column) {
+    final Object rawValue = row.get(column);
+    if (rawValue instanceof byte[]) {
+      return ((byte[]) rawValue)[0] == 1;
+    } else {
+      return ((byte)rawValue) == 1;
+    }
+  }
+
+  public Byte getByte(final String column) {
+    return (Byte) row.get(column);
+  }
+
+  public Byte getByte(final int column) {
+    return (Byte) row.get(column);
+  }
+
+  public LocalDateTime getDate(final int column) {
+    return (LocalDateTime) row.get(column);
+  }
+
+  public LocalDateTime getDate(final String column) {
+    return (LocalDateTime) row.get(column);
+  }
+
+  public Float getFloat(final int column) {
+    return (Float)row.get(column);
+  }
+
+  public Float getFloat(final String column) {
+    return (Float)row.get(column);
+  }
+
+  public Double getDouble(final int column) {
+    return (Double)row.get(column);
+  }
+
+  public Double getDouble(final String column) {
+    return (Double)row.get(column);
+  }
+
+  public String getString(final int column) {
+    return (String) row.get(column);
+  }
+
+  public String getString(final String column) {
+    return (String) row.get(column);
+  }
+
+  public Object getRaw(final int column) {
+    return row.get(column);
+  }
+
+  public Object getRaw(final String column) {
+    return row.get(column);
+  }
+
+}

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/springsupport/MySqlConnectionPoolFactoryBean.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/springsupport/MySqlConnectionPoolFactoryBean.java
@@ -1,0 +1,71 @@
+package com.outbrain.ob1k.db.experimental.springsupport;
+
+import com.outbrain.ob1k.db.DbConnectionPool;
+import com.outbrain.ob1k.db.MySqlConnectionPoolBuilder;
+import com.outbrain.swinfra.metrics.api.MetricFactory;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Spring support for MySqlConnectionPool creation
+ * @author Eran Harel
+ */
+public class MySqlConnectionPoolFactoryBean implements FactoryBean {
+
+  private final MySqlConnectionPoolBuilder builder;
+
+  public MySqlConnectionPoolFactoryBean(final String connectionString, final String username) {
+    builder = MySqlConnectionPoolBuilder.newBuilder(connectionString, username);
+  }
+
+  @Override
+  public Object getObject() throws Exception {
+    return builder.build();
+  }
+
+  @Override
+  public Class<?> getObjectType() {
+    return DbConnectionPool.class;
+  }
+
+  @Override
+  public boolean isSingleton() {
+    return true;
+  }
+
+  public void setDatabase(final String database) {
+    builder.forDatabase(database);
+  }
+
+  public void setPassword(final String password) {
+    builder.password(password);
+  }
+
+  public void setConnectTimeout(final long connectTimeoutMilliSeconds) {
+    builder.connectTimeout(connectTimeoutMilliSeconds);
+  }
+
+  public void setQueryTimeout(final long queryTimeoutMilliSeconds) {
+    builder.queryTimeout(queryTimeoutMilliSeconds);
+  }
+
+  public void setMaxConnections(final int maxConnections) {
+    builder.maxConnections(maxConnections);
+  }
+
+  public void setMaxQueueSize(final Integer maxQueueSize) {
+    builder.maxQueueSize(maxQueueSize);
+  }
+
+  public void setMaxIdleTimeMs(final Integer maxIdleTimeMs) {
+    builder.maxIdleTimeMs(maxIdleTimeMs);
+  }
+
+  public void setValidationIntervalMs(final Integer validationIntervalMs) {
+    builder.validationIntervalMs(validationIntervalMs);
+  }
+
+  public void setMetricFactory(final MetricFactory metricFactory) {
+    builder.withMetrics(metricFactory);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
     </developer>
   </developers>
 
+  <repositories>
+    <repository>
+      <id>jcenter</id>
+      <url>https://jcenter.bintray.com/</url>
+    </repository>
+  </repositories>
+
   <modules>
     <module>util-metrics</module>
     <module>ob1k-concurrent</module>


### PR DESCRIPTION
it is a sub package of ob1k-db
users can use the new classes as a drop-in replacement, simply by replacing
usages of package 'com.outbrain.ob1k.db' by 'com.outbrain.ob1k.db.experimental'
There might be minor api changes because of the new dependency:
Optional instead of Option, Duration from java 8 etc'