### PR TITLE
made TypedRowData an abstract class to preserve compatibilty

### DIFF
--- a/ob1k-db/pom.xml
+++ b/ob1k-db/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.github.jasync-sql</groupId>
       <artifactId>jasync-mysql</artifactId>
-      <version>0.8.31</version>
+      <version>0.8.32</version>
     </dependency>
 
     <dependency>

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/TypedRowData.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/TypedRowData.java
@@ -2,40 +2,40 @@ package com.outbrain.ob1k.db;
 
 import org.joda.time.LocalDateTime;
 
-public interface TypedRowData {
-  Integer getInt(int column);
+public abstract class TypedRowData {
+  public abstract Integer getInt(int column);
 
-  Integer getInt(String column);
+  public abstract Integer getInt(String column);
 
-  Long getLong(int column);
+  public abstract Long getLong(int column);
 
-  Long getLong(String column);
+  public abstract Long getLong(String column);
 
-  Boolean getBoolean(int column);
+  public abstract Boolean getBoolean(int column);
 
-  Boolean getBoolean(String column);
+  public abstract Boolean getBoolean(String column);
 
-  Byte getByte(String column);
+  public abstract Byte getByte(String column);
 
-  Byte getByte(int column);
+  public abstract Byte getByte(int column);
 
-  LocalDateTime getDate(int column);
+  public abstract LocalDateTime getDate(int column);
 
-  LocalDateTime getDate(String column);
+  public abstract LocalDateTime getDate(String column);
 
-  Float getFloat(int column);
+  public abstract Float getFloat(int column);
 
-  Float getFloat(String column);
+  public abstract Float getFloat(String column);
 
-  Double getDouble(int column);
+  public abstract Double getDouble(int column);
 
-  Double getDouble(String column);
+  public abstract Double getDouble(String column);
 
-  String getString(int column);
+  public abstract String getString(int column);
 
-  String getString(String column);
+  public abstract String getString(String column);
 
-  Object getRaw(int column);
+  public abstract Object getRaw(int column);
 
-  Object getRaw(String column);
+  public abstract Object getRaw(String column);
 }

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/TypedRowDataImpl.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/TypedRowDataImpl.java
@@ -8,7 +8,7 @@ import org.joda.time.LocalDateTime;
  * Date: 10/1/13
  * Time: 2:11 PM
  */
-public class TypedRowDataImpl implements TypedRowData {
+public class TypedRowDataImpl extends TypedRowData {
   private final RowData row;
 
   public TypedRowDataImpl(final RowData row) {

--- a/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/TypedRowDataImpl.java
+++ b/ob1k-db/src/main/java/com/outbrain/ob1k/db/experimental/TypedRowDataImpl.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 /**
  *
  */
-public class TypedRowDataImpl implements com.outbrain.ob1k.db.TypedRowData {
+public class TypedRowDataImpl extends com.outbrain.ob1k.db.TypedRowData {
   private final RowData row;
 
   public TypedRowDataImpl(RowData row) {


### PR DESCRIPTION
update to jasync-mysql version 0.8.32

error was: Caused by: java.lang.IncompatibleClassChangeError: Found interface com.outbrain.ob1k.db.TypedRowData, but class was expected